### PR TITLE
fix: health check falls back to OneCLI API when CLI unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ groups/global/*
 
 # Temp files
 .tmp-*
+ecosystem.config.cjs
 
 # OS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,36 @@ systemctl --user stop nanoclaw
 systemctl --user restart nanoclaw
 ```
 
+## Windows Setup Notes
+
+ClawDad runs on Windows via Git Bash. These are the known gotchas:
+
+**Docker Desktop PATH:** After installing Docker Desktop via `winget`, the `docker` CLI is not in the Git Bash PATH until you add it manually:
+```bash
+echo 'export PATH="/c/Program Files/Docker/Docker/resources/bin:$PATH"' >> ~/.bashrc
+```
+Restart your shell after adding this.
+
+**OneCLI CLI not supported:** The `onecli` CLI installer (`onecli.sh/cli/install`) does not support Git Bash / MSYS2. Use the OneCLI dashboard at `http://localhost:10254` or the REST API to manage secrets instead:
+```bash
+# Register a secret via API
+curl -X POST http://127.0.0.1:10254/api/secrets \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Anthropic","type":"anthropic","value":"YOUR_KEY","hostPattern":"api.anthropic.com"}'
+
+# List secrets
+curl -s http://127.0.0.1:10254/api/secrets
+```
+
+**Health check shows Anthropic "missing":** The health endpoint uses `onecli secrets list` (the CLI) to verify credentials. Since the CLI doesn't work on Windows, it always reports `missing` even when the secret is correctly registered via the API. Agents still work.
+
+**pm2 log capture:** pm2 may silently fail to capture stdout/stderr on Windows. If `pm2 logs` shows nothing, run the service directly instead:
+```bash
+node dist/index.js > logs/clawdad.log 2>&1 &
+```
+
+**Service auto-start:** The built-in service setup (`npx tsx setup/index.ts --step service`) only supports macOS (launchd) and Linux (systemd). On Windows, start manually after reboot or create a Windows Task Scheduler entry.
+
 ## Troubleshooting
 
 **WhatsApp not connecting after upgrade:** WhatsApp is now a separate skill, not bundled in core. Run `/add-whatsapp` (or `npx tsx scripts/apply-skill.ts .claude/skills/add-whatsapp && npm run build`) to install it. Existing auth credentials and groups are preserved.

--- a/src/health.ts
+++ b/src/health.ts
@@ -73,7 +73,26 @@ function checkOneCLI(): Promise<HealthStatus['onecli']> {
   });
 }
 
-function checkAnthropic(): HealthStatus['anthropic'] {
+function matchesAnthropicHost(
+  secrets: Array<{ hostPattern?: string }>,
+): boolean {
+  const envVars = readEnvFile(['ANTHROPIC_BASE_URL']);
+  const baseUrl = process.env.ANTHROPIC_BASE_URL || envVars.ANTHROPIC_BASE_URL;
+  const anthropicHost = baseUrl
+    ? new URL(baseUrl).hostname
+    : 'api.anthropic.com';
+  return (
+    Array.isArray(secrets) &&
+    secrets.some(
+      (s) =>
+        s.hostPattern &&
+        (s.hostPattern.includes('anthropic.com') ||
+          s.hostPattern.includes(anthropicHost)),
+    )
+  );
+}
+
+function checkAnthropicViaCli(): HealthStatus['anthropic'] | null {
   try {
     const output = execSync('onecli secrets list', {
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -81,26 +100,44 @@ function checkAnthropic(): HealthStatus['anthropic'] {
       timeout: 5000,
     });
     const secrets = JSON.parse(output);
-    // Look for a secret with hostPattern matching anthropic.
-    // Read ANTHROPIC_BASE_URL from .env since launchd/systemd won't have it in process.env.
-    const envVars = readEnvFile(['ANTHROPIC_BASE_URL']);
-    const baseUrl =
-      process.env.ANTHROPIC_BASE_URL || envVars.ANTHROPIC_BASE_URL;
-    const anthropicHost = baseUrl
-      ? new URL(baseUrl).hostname
-      : 'api.anthropic.com';
-    const found =
-      Array.isArray(secrets) &&
-      secrets.some(
-        (s: { hostPattern?: string }) =>
-          s.hostPattern &&
-          (s.hostPattern.includes('anthropic.com') ||
-            s.hostPattern.includes(anthropicHost)),
-      );
-    return { status: found ? 'configured' : 'missing' };
+    return { status: matchesAnthropicHost(secrets) ? 'configured' : 'missing' };
   } catch {
-    return { status: 'missing' };
+    return null;
   }
+}
+
+function checkAnthropicViaApi(): Promise<HealthStatus['anthropic']> {
+  return new Promise((resolve) => {
+    const url = new URL('/api/secrets', ONECLI_URL);
+    const req = http.get(url, { timeout: 3000 }, (res) => {
+      let data = '';
+      res.on('data', (chunk: string) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        try {
+          const secrets = JSON.parse(data);
+          resolve({
+            status: matchesAnthropicHost(secrets) ? 'configured' : 'missing',
+          });
+        } catch {
+          resolve({ status: 'missing' });
+        }
+      });
+    });
+    req.on('error', () => resolve({ status: 'missing' }));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ status: 'missing' });
+    });
+  });
+}
+
+async function checkAnthropic(): Promise<HealthStatus['anthropic']> {
+  // Try CLI first (fast, no network), fall back to OneCLI HTTP API
+  const cliResult = checkAnthropicViaCli();
+  if (cliResult) return cliResult;
+  return checkAnthropicViaApi();
 }
 
 function checkContainerImage(): HealthStatus['container_image'] {
@@ -120,11 +157,11 @@ function checkContainerImage(): HealthStatus['container_image'] {
 
 export async function getHealthStatus(): Promise<HealthStatus> {
   // Run checks concurrently where possible
-  const [docker, onecli] = await Promise.all([
+  const [docker, onecli, anthropic] = await Promise.all([
     Promise.resolve(checkDocker()),
     checkOneCLI(),
+    checkAnthropic(),
   ]);
-  const anthropic = checkAnthropic();
   const containerImage = checkContainerImage();
 
   const allGood =


### PR DESCRIPTION
## Summary
- The Anthropic credential health check relied on `onecli secrets list` (the CLI binary), which can't be installed on Windows (Git Bash / MSYS2)
- Now tries the CLI first, then falls back to the OneCLI HTTP API at `/api/secrets` — matching the pattern already used by `checkOneCLI()`
- Also runs the check concurrently with Docker and OneCLI checks via `Promise.all`

## Test plan
- [x] Verified on Windows 11 (Git Bash) — health endpoint now returns `anthropic: "configured"` 
- [x] Build passes (`npm run build`)
- [ ] Verify on macOS/Linux that CLI path still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)