### PR TITLE
fix: auto-recover OneCLI gateway after laptop sleep/wake

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -248,10 +248,11 @@ async function buildContainerArgs(
   if (onecliApplied) {
     logger.info({ containerName }, 'OneCLI gateway config applied');
   } else {
-    logger.warn(
+    logger.error(
       { containerName },
-      'OneCLI gateway not reachable — container will have no credentials',
+      'OneCLI gateway not reachable — aborting container spawn',
     );
+    throw new Error('OneCLI gateway not reachable');
   }
 
   // Pass through extra environment variables from .env to the container.
@@ -329,11 +330,17 @@ export async function runContainerAgent(
   const agentIdentifier = input.isMain
     ? undefined
     : group.folder.toLowerCase().replace(/_/g, '-');
-  const containerArgs = await buildContainerArgs(
-    mounts,
-    containerName,
-    agentIdentifier,
-  );
+  let containerArgs: string[];
+  try {
+    containerArgs = await buildContainerArgs(
+      mounts,
+      containerName,
+      agentIdentifier,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { status: 'error', result: null, error: msg };
+  }
 
   logger.debug(
     {

--- a/src/health.ts
+++ b/src/health.ts
@@ -55,22 +55,27 @@ function checkDocker(): HealthStatus['docker'] {
   }
 }
 
-function checkOneCLI(): Promise<HealthStatus['onecli']> {
+/** Returns true if the OneCLI gateway is responding on its health endpoint. */
+export function checkGateway(): Promise<boolean> {
   return new Promise((resolve) => {
     const url = new URL('/api/health', ONECLI_URL);
     const req = http.get(url, { timeout: 3000 }, (res) => {
-      // Any response means the gateway is up
       res.resume();
-      resolve({ status: 'running', url: ONECLI_URL });
+      resolve(true);
     });
-    req.on('error', () => {
-      resolve({ status: 'not_found', url: ONECLI_URL });
-    });
+    req.on('error', () => resolve(false));
     req.on('timeout', () => {
       req.destroy();
-      resolve({ status: 'not_found', url: ONECLI_URL });
+      resolve(false);
     });
   });
+}
+
+function checkOneCLI(): Promise<HealthStatus['onecli']> {
+  return checkGateway().then((healthy) => ({
+    status: healthy ? 'running' : 'not_found',
+    url: ONECLI_URL,
+  }));
 }
 
 function checkAnthropic(): HealthStatus['anthropic'] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import {
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { logger } from './logger.js';
+import { checkGateway } from './health.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
@@ -103,7 +104,29 @@ const onecli = await import('@onecli-sh/sdk')
   .then((m) => new m.OneCLI({ url: ONECLI_URL }))
   .catch(() => ({
     ensureAgent: async () => ({ created: false }),
+    applyContainerConfig: async () => false,
   }));
+
+const GATEWAY_CHECK_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Probes the OneCLI gateway and attempts recovery if it's down.
+ * The gateway dies on laptop sleep; applyContainerConfig with empty args
+ * triggers the SDK to restart it.
+ */
+async function ensureGatewayHealthy(): Promise<boolean> {
+  const healthy = await checkGateway();
+  if (healthy) return true;
+
+  logger.warn('OneCLI gateway unreachable, attempting recovery...');
+  const recovered = await onecli.applyContainerConfig([], {});
+  if (recovered) {
+    logger.info('OneCLI gateway recovered');
+  } else {
+    logger.error('OneCLI gateway recovery failed');
+  }
+  return recovered;
+}
 
 function ensureOneCLIAgent(jid: string, group: RegisteredGroup): void {
   if (group.isMain) return;
@@ -1043,6 +1066,14 @@ async function main(): Promise<void> {
   });
   queue.setProcessMessagesFn(processGroupMessages);
   recoverPendingMessages();
+
+  // Startup gateway probe + periodic recovery (survives laptop sleep/wake)
+  ensureGatewayHealthy().catch(() => {});
+  setInterval(
+    () => ensureGatewayHealthy().catch(() => {}),
+    GATEWAY_CHECK_INTERVAL,
+  );
+
   startMessageLoop().catch((err) => {
     logger.fatal({ err }, 'Message loop crashed unexpectedly');
     process.exit(1);


### PR DESCRIPTION
## Summary
- Adds periodic (5-min) gateway health check with auto-recovery via `applyContainerConfig`
- Aborts container spawn when gateway is unreachable instead of running without credentials for 30+ minutes
- Extracts `checkGateway()` helper from health.ts for reuse

## Context
After laptop sleep/wake cycles, the OneCLI gateway process dies. Containers would spawn without credentials and either fail silently or hang until timeout. This was discovered after a weekend with the laptop closed — bug triage and daily briefing agents were failing for hours.

## Test plan
- Build passes (`npm run build`)
- Kill the OneCLI gateway process manually; verify the 5-min check detects and recovers it
- Trigger a scheduled task with gateway down; verify it aborts fast instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)