### PR TITLE
fix: typing indicator vanishes mid-run and isSystem applied to wrong group

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -107,10 +107,14 @@ export class WebChannel implements Channel {
       jid.startsWith('web:'),
     );
 
-    // If a web group exists but lost isSystem (not persisted in DB), restore it
+    // If any web group exists, skip creating a default — but only restore
+    // isSystem on the group that is actually marked as main.
     if (existingJid) {
-      if (!groups[existingJid].isSystem) {
-        groups[existingJid].isSystem = true;
+      const mainJid = Object.keys(groups).find(
+        (jid) => jid.startsWith('web:') && groups[jid].isMain,
+      );
+      if (mainJid && !groups[mainJid].isSystem) {
+        groups[mainJid].isSystem = true;
       }
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -483,6 +483,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         resetIdleTimer();
       }
 
+      if (!result.status) {
+        // Intermediate result — agent is still running. Re-assert typing so
+        // the frontend indicator comes back after clearing on message receipt.
+        await responseChannel.setTyping?.(responseJid, true, threadId);
+      }
+
       if (result.status === 'success') {
         queue.notifyIdle(chatJid);
       }


### PR DESCRIPTION
## Summary
- **Typing indicator fix**: Multi-turn agents that send intermediate results cause the frontend to clear the "Thinking..." indicator on message receipt. The backend now re-asserts `typing: true` after each intermediate result so the indicator stays visible while the agent continues working.
- **isSystem group fix**: `ensureDefaultGroup()` was forcing `isSystem` on the first alphabetical web group instead of the one marked `isMain`, causing a random group to become the system group after restart.

## Test plan
- [ ] Send a message to a multi-turn agent (one that uses tools and sends intermediate results) — verify the typing indicator stays visible throughout the run
- [ ] Verify the indicator clears when the agent finishes and goes idle
- [ ] Restart the service with multiple web groups, none marked `isMain` — verify no group gets `isSystem: true`
- [ ] Restart with one group marked `isMain` — verify only that group gets `isSystem: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)