### PR TITLE
feat: stream intermediate agent text + reliability fixes

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -53,6 +53,7 @@ interface ContainerOutput {
   newSessionId?: string;
   error?: string;
   usage?: UsageData;
+  textsAlreadyStreamed?: number;
 }
 
 interface SessionEntry {
@@ -132,6 +133,8 @@ const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 const PROGRESS_START_MARKER = '---NANOCLAW_PROGRESS_START---';
 const PROGRESS_END_MARKER = '---NANOCLAW_PROGRESS_END---';
+const TEXT_START_MARKER = '---NANOCLAW_TEXT_START---';
+const TEXT_END_MARKER = '---NANOCLAW_TEXT_END---';
 
 interface ProgressEvent {
   tool?: string;
@@ -149,6 +152,12 @@ function writeProgress(event: ProgressEvent): void {
   console.log(PROGRESS_START_MARKER);
   console.log(JSON.stringify(event));
   console.log(PROGRESS_END_MARKER);
+}
+
+function writeText(text: string): void {
+  console.log(TEXT_START_MARKER);
+  console.log(JSON.stringify({ text, timestamp: new Date().toISOString() }));
+  console.log(TEXT_END_MARKER);
 }
 
 function log(message: string): void {
@@ -546,6 +555,7 @@ async function runQuery(
         for (const block of assistantMsg.message.content) {
           if (block.type === 'text' && block.text) {
             assistantTexts.push(block.text);
+            writeText(block.text);
           }
           if (block.type === 'tool_use' && block.name) {
             const summary = summarizeTool(block.name, block.input);
@@ -602,6 +612,7 @@ async function runQuery(
         result: textResult || null,
         newSessionId,
         usage: accumulatedUsage,
+        textsAlreadyStreamed: assistantTexts.length,
       });
       // Reset retry counter on successful text output
       if (textResult) {
@@ -618,17 +629,16 @@ async function runQuery(
   ipcPolling = false;
   log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
 
-  // If no result was emitted but we have assistant text, send it as the result
-  // This handles cases where the agent uses interactive elements (action buttons, rich blocks)
-  // and the SDK doesn't generate a result message because it's waiting for user input
+  // If no result was emitted but we have assistant text, send completion.
+  // Text was already streamed via writeText markers — just emit usage/session.
   if (resultCount === 0 && assistantTexts.length > 0) {
-    const combinedText = assistantTexts.join('\n\n');
-    log(`No result message received, using collected assistant text (${combinedText.length} chars)`);
+    log(`No result message received, ${assistantTexts.length} text blocks already streamed`);
     writeOutput({
       status: 'success',
-      result: combinedText,
+      result: null,
       newSessionId,
       usage: accumulatedUsage,
+      textsAlreadyStreamed: assistantTexts.length,
     });
   }
 

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -20,6 +20,8 @@ Wrap internal reasoning in `<internal>` tags — it's logged but not sent:
 Here's what I found...
 ```
 
+**CRITICAL:** Only use `<internal>` for brief reasoning notes (plan-of-action, self-reminders). NEVER wrap content meant for the user — drafts, summaries, reports, :::blocks, code output, or any deliverable — in `<internal>` tags. Everything inside `<internal>` is **permanently stripped** before delivery. If you compile a draft and then say "it's above," but the draft was inside `<internal>` tags, the user will see nothing.
+
 ### Sub-agents and teammates
 
 When working as a sub-agent or teammate, only use `send_message` if instructed by the main agent.

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -22,6 +22,23 @@ Here's what I found...
 
 **CRITICAL:** Only use `<internal>` for brief reasoning notes (plan-of-action, self-reminders). NEVER wrap content meant for the user — drafts, summaries, reports, :::blocks, code output, or any deliverable — in `<internal>` tags. Everything inside `<internal>` is **permanently stripped** before delivery. If you compile a draft and then say "it's above," but the draft was inside `<internal>` tags, the user will see nothing.
 
+### Message delivery — what the user actually sees
+
+**Only your FINAL text output is delivered to the user.** Text you produce between tool calls is part of your reasoning chain but is NOT sent. If you write a long draft, then make tool calls (logging, saving files), and then say "the draft is above" — the user only sees "the draft is above." The draft itself is lost.
+
+**Rules:**
+1. **All user-facing content must be in your final response** — the last text you produce after all tool calls are done. Do not make tool calls after writing content meant for the user.
+2. **If you need to do work after producing content**, use `mcp__nanoclaw__send_message` to deliver the content first, then continue with tool calls. `send_message` delivers immediately regardless of what happens after.
+3. **Never say "see above" or "the draft is above"** unless you used `send_message` to deliver it. If it's in your final response, say "here's the draft" — not "above."
+
+**Pattern — long content with follow-up work:**
+```
+1. Do all research/tool calls first
+2. Use send_message to deliver the main content
+3. Do any follow-up work (logging, saving files)
+4. Final response: brief acknowledgment only
+```
+
 ### Sub-agents and teammates
 
 When working as a sub-agent or teammate, only use `send_message` if instructed by the main agent.
@@ -112,21 +129,19 @@ The tool returns immediately — it does NOT block waiting for the user. The flo
 Credentials are injected by the credential proxy. Always use `/workspace/scripts/api.sh` for service API calls — it routes through the proxy automatically:
 
 ```bash
-# GitHub
-/workspace/scripts/api.sh github GET "https://api.github.com/user" \
-  -H "Authorization: token $GITHUB_TOKEN"
+/workspace/scripts/api.sh <service_label> <METHOD> <URL> [CURL_ARGS...]
+```
 
-# GitLab
-/workspace/scripts/api.sh gitlab GET "https://gitlab.com/api/v4/projects" \
-  -H "PRIVATE-TOKEN: $GITLAB_TOKEN"
+The first argument is a **service label** — a short name for logging and error tracking. Common labels: `github`, `gitlab`, `atlassian`, `harness`, `blackduck`, `launchdarkly`. Use any label for custom services.
 
-# Atlassian
-/workspace/scripts/api.sh atlassian GET "https://yourorg.atlassian.net/rest/api/3/myself" \
-  -u "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN"
+**How auth works:** Your environment variables (e.g. `$GITHUB_TOKEN`, `$ATLASSIAN_API_TOKEN`) contain **placeholders**, not real secrets. The credential proxy substitutes real values at request time. You MUST pass auth headers/flags explicitly on every call — the proxy only replaces the placeholder values, it doesn't add headers for you.
 
-# Custom services — the env var name matches what was registered
-/workspace/scripts/api.sh myservice GET "https://api.example.com/data" \
-  -H "Authorization: Bearer $MYSERVICE_TOKEN"
+**Common auth patterns:**
+```bash
+# Bearer token:  -H "Authorization: token $SERVICE_TOKEN"
+# Private token: -H "PRIVATE-TOKEN: $SERVICE_TOKEN"
+# Basic auth:    -u "$SERVICE_EMAIL:$SERVICE_API_TOKEN"
+# API key:       -H "x-api-key: $SERVICE_API_KEY"
 ```
 
 The proxy replaces credential placeholders with real values at request time. Newly registered credentials work immediately — no container restart needed.
@@ -140,6 +155,17 @@ The proxy replaces credential placeholders with real values at request time. New
 - NEVER echo, log, or print credential values — they contain placeholders, not real secrets
 - NEVER use raw curl for authenticated API calls — always use `api.sh`
 - If an API call fails with 401/403, call `request_credential` — the token may have expired
+
+### Service-specific configuration
+
+Service URLs and auth details are provided as environment variables. Check what's available with `env | grep -E '(URL|EMAIL|ACCOUNT)' | sort` — this shows base URLs, emails, and account IDs for connected services. Your group's CLAUDE.md should document specific API endpoints and patterns relevant to your domain.
+
+### API pitfalls to avoid
+
+- **Deprecated endpoints:** Some service APIs deprecate endpoints over time (returning 410 Gone). If you get a 410, check the service's current API docs for the replacement endpoint. Do not retry the same URL.
+- **URL encoding in GET queries:** URL-encode JQL, CQL, or other query strings. Use `--data-urlencode` for complex query params or switch to POST with a JSON body.
+- **Rate limits:** If you get 429 responses, back off and retry with increasing delays. Log the rate limit event.
+- **Pagination:** Most APIs return paginated results. Check for `nextPage`, `startAt`/`total`, or `cursor` fields in responses and paginate as needed.
 
 ## Event Logging
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -36,6 +36,8 @@ const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 const PROGRESS_START_MARKER = '---NANOCLAW_PROGRESS_START---';
 const PROGRESS_END_MARKER = '---NANOCLAW_PROGRESS_END---';
+const TEXT_START_MARKER = '---NANOCLAW_TEXT_START---';
+const TEXT_END_MARKER = '---NANOCLAW_TEXT_END---';
 
 export interface ProgressEvent {
   tool?: string;
@@ -76,6 +78,7 @@ export interface ContainerOutput {
   newSessionId?: string;
   error?: string;
   usage?: UsageData;
+  textsAlreadyStreamed?: number;
 }
 
 interface VolumeMount {
@@ -397,6 +400,7 @@ export async function runContainerAgent(
   onProcess: (proc: ChildProcess, containerName: string) => void,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   onProgress?: (event: ProgressEvent) => void,
+  onText?: (text: string) => Promise<void>,
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
 
@@ -513,8 +517,8 @@ export async function runContainerAgent(
         }
       }
 
-      // Stream-parse for output and progress markers
-      if (onOutput || onProgress) {
+      // Stream-parse for output, progress, and text markers
+      if (onOutput || onProgress || onText) {
         parseBuffer += chunk;
 
         // Parse progress markers (lightweight, no Promise chain)
@@ -537,6 +541,28 @@ export async function runContainerAgent(
               /* ignore malformed progress */
             }
             // Activity detected — reset timeout
+            resetTimeout();
+          }
+        }
+
+        // Parse text markers (async, ordered via outputChain)
+        if (onText) {
+          let textStart: number;
+          while ((textStart = parseBuffer.indexOf(TEXT_START_MARKER)) !== -1) {
+            const textEnd = parseBuffer.indexOf(TEXT_END_MARKER, textStart);
+            if (textEnd === -1) break;
+            const textJson = parseBuffer
+              .slice(textStart + TEXT_START_MARKER.length, textEnd)
+              .trim();
+            parseBuffer = parseBuffer.slice(textEnd + TEXT_END_MARKER.length);
+            try {
+              const parsed = JSON.parse(textJson);
+              if (parsed.text) {
+                outputChain = outputChain.then(() => onText(parsed.text));
+              }
+            } catch {
+              /* ignore malformed text */
+            }
             resetTimeout();
           }
         }

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -311,7 +311,15 @@ function handleForward(
   );
 
   // Build outbound headers with placeholder substitution
-  const parsed = new URL(targetUrl);
+  let parsed: URL;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    logger.warn({ targetUrl }, 'Credential proxy /forward: invalid URL');
+    res.writeHead(400);
+    res.end(`Invalid X-Forward-To URL: ${targetUrl}`);
+    return;
+  }
   const outIsHttps = parsed.protocol === 'https:';
   const makeRequest = outIsHttps ? httpsRequest : httpRequest;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,6 +854,22 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             { agent: agent.id, responseJid, threadId: threadId || null },
             `Agent output: ${raw.length} chars → ${threadId ? 'thread' : 'main'}`,
           );
+          if (raw.length > 0 && text.length === 0) {
+            logger.warn(
+              { agent: agent.id, responseJid, rawLen: raw.length },
+              'Agent output entirely stripped by <internal> tag removal — user sees nothing',
+            );
+          } else if (raw.length - text.length > 500) {
+            logger.info(
+              {
+                agent: agent.id,
+                responseJid,
+                rawLen: raw.length,
+                strippedLen: text.length,
+              },
+              `<internal> tags stripped ${raw.length - text.length} chars from agent output`,
+            );
+          }
           if (text) {
             // Re-set agent name before each send — parallel delegations
             // on the same chatJid can clobber the shared activeAgentName
@@ -1620,7 +1636,15 @@ async function main(): Promise<void> {
       }
       // Always strip <internal> tags — agents use these for reasoning
       const stripped = stripInternalTags(rawText);
-      if (!stripped) return;
+      if (!stripped) {
+        if (rawText.trim().length > 0) {
+          logger.warn(
+            { jid, rawLen: rawText.length },
+            'Scheduler output entirely stripped by <internal> tag removal — message dropped',
+          );
+        }
+        return;
+      }
       // Web channel renders blocks client-side — formatOutbound would corrupt
       // :::blocks JSON by transforming markdown inside the fences.
       const text =
@@ -1641,7 +1665,15 @@ async function main(): Promise<void> {
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       // Always strip <internal> tags — agents use these for reasoning
       const stripped = stripInternalTags(rawText);
-      if (!stripped) return Promise.resolve();
+      if (!stripped) {
+        if (rawText.trim().length > 0) {
+          logger.warn(
+            { jid, rawLen: rawText.length },
+            'IPC send_message entirely stripped by <internal> tag removal — message dropped',
+          );
+        }
+        return Promise.resolve();
+      }
       // Web channel renders blocks client-side — formatOutbound would corrupt
       // :::blocks JSON by transforming markdown inside the fences.
       const text =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1104,6 +1104,11 @@ async function runAgent(
         );
         delete sessions[agentId];
         deleteSession(agentId);
+        // Also clear the legacy group-folder key — session resolution falls
+        // back to sessions[group.folder] for default agents, so the stale ID
+        // would be picked up again on retry if only the agent key is cleared.
+        delete sessions[group.folder];
+        deleteSession(group.folder);
       }
       logger.error(
         { agent: agentId, error: output.error },

--- a/src/index.ts
+++ b/src/index.ts
@@ -540,6 +540,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           chatJid,
           onOutput,
           undefined,
+          undefined, // onText — session commands don't stream intermediate text
           defaultAgent,
         );
       },
@@ -719,20 +720,27 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             chatJid,
             async (result) => {
               if (result.result) {
-                const raw =
-                  typeof result.result === 'string'
-                    ? result.result
-                    : JSON.stringify(result.result);
-                const text = raw
-                  .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-                  .trim();
-                if (text) {
-                  setActiveAgentName(responseJid, agent.displayName);
-                  await responseChannel.sendMessage(
-                    responseJid,
-                    text,
-                    threadId,
-                  );
+                if (
+                  result.textsAlreadyStreamed &&
+                  result.textsAlreadyStreamed > 0
+                ) {
+                  // Text already delivered via intermediate markers
+                } else {
+                  const raw =
+                    typeof result.result === 'string'
+                      ? result.result
+                      : JSON.stringify(result.result);
+                  const text = raw
+                    .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                    .trim();
+                  if (text) {
+                    setActiveAgentName(responseJid, agent.displayName);
+                    await responseChannel.sendMessage(
+                      responseJid,
+                      text,
+                      threadId,
+                    );
+                  }
                 }
               }
               if (result.status === 'success' || result.status === 'error') {
@@ -740,6 +748,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               }
             },
             (event) => broadcastProgress(responseJid, event),
+            async (rawText) => {
+              const text = rawText
+                .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                .trim();
+              if (!text) return;
+              setActiveAgentName(responseJid, agent.displayName);
+              await responseChannel.sendMessage(responseJid, text, threadId);
+            },
             agent,
             true, // isDelegation
           );
@@ -843,40 +859,53 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       chatJid,
       async (result) => {
         if (result.result) {
-          const raw =
-            typeof result.result === 'string'
-              ? result.result
-              : JSON.stringify(result.result);
-          const text = raw
-            .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-            .trim();
-          logger.info(
-            { agent: agent.id, responseJid, threadId: threadId || null },
-            `Agent output: ${raw.length} chars → ${threadId ? 'thread' : 'main'}`,
-          );
-          if (raw.length > 0 && text.length === 0) {
-            logger.warn(
-              { agent: agent.id, responseJid, rawLen: raw.length },
-              'Agent output entirely stripped by <internal> tag removal — user sees nothing',
-            );
-          } else if (raw.length - text.length > 500) {
+          // If intermediate texts were already streamed to the user, skip
+          // re-sending the final result to avoid duplicate content.
+          if (result.textsAlreadyStreamed && result.textsAlreadyStreamed > 0) {
             logger.info(
               {
                 agent: agent.id,
                 responseJid,
-                rawLen: raw.length,
-                strippedLen: text.length,
+                textsStreamed: result.textsAlreadyStreamed,
               },
-              `<internal> tags stripped ${raw.length - text.length} chars from agent output`,
+              'Final result skipped — text already streamed via intermediate markers',
             );
-          }
-          if (text) {
-            // Re-set agent name before each send — parallel delegations
-            // on the same chatJid can clobber the shared activeAgentName
-            setActiveAgentName(responseJid, agent.displayName);
-            await responseChannel.sendMessage(responseJid, text, threadId);
             outputSentToUser = true;
             outputSentForCurrentQuery = true;
+          } else {
+            const raw =
+              typeof result.result === 'string'
+                ? result.result
+                : JSON.stringify(result.result);
+            const text = raw
+              .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+              .trim();
+            logger.info(
+              { agent: agent.id, responseJid, threadId: threadId || null },
+              `Agent output: ${raw.length} chars → ${threadId ? 'thread' : 'main'}`,
+            );
+            if (raw.length > 0 && text.length === 0) {
+              logger.warn(
+                { agent: agent.id, responseJid, rawLen: raw.length },
+                'Agent output entirely stripped by <internal> tag removal — user sees nothing',
+              );
+            } else if (raw.length - text.length > 500) {
+              logger.info(
+                {
+                  agent: agent.id,
+                  responseJid,
+                  rawLen: raw.length,
+                  strippedLen: text.length,
+                },
+                `<internal> tags stripped ${raw.length - text.length} chars from agent output`,
+              );
+            }
+            if (text) {
+              setActiveAgentName(responseJid, agent.displayName);
+              await responseChannel.sendMessage(responseJid, text, threadId);
+              outputSentToUser = true;
+              outputSentForCurrentQuery = true;
+            }
           }
           resetIdleTimer();
         }
@@ -901,18 +930,17 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           }
 
           queue.notifyIdle(chatJid);
-          if (!outputSentForCurrentQuery && !result.result) {
+          if (
+            !outputSentForCurrentQuery &&
+            !result.result &&
+            !(result.textsAlreadyStreamed && result.textsAlreadyStreamed > 0)
+          ) {
             logger.warn(
               { agent: agent.id },
               'Agent returned null result after retry — silent completion',
             );
           }
           await responseChannel.setTyping?.(responseJid, false, threadId);
-          // Only reset the flag when the success event carried actual output.
-          // The agent-runner emits a second {status:'success', result:null}
-          // as a session-update marker after the query loop — resetting here
-          // unconditionally caused the null-result warning to fire spuriously
-          // on that second event even when the first event delivered text.
           if (result.result) {
             outputSentForCurrentQuery = false;
           }
@@ -925,6 +953,18 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       },
       (event) => {
         broadcastProgress(responseJid, event);
+      },
+      async (rawText) => {
+        // Intermediate text block — deliver immediately
+        const text = rawText
+          .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+          .trim();
+        if (!text) return;
+        setActiveAgentName(responseJid, agent.displayName);
+        await responseChannel.sendMessage(responseJid, text, threadId);
+        outputSentToUser = true;
+        outputSentForCurrentQuery = true;
+        resetIdleTimer();
       },
       agent,
     );
@@ -978,6 +1018,7 @@ async function runAgent(
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   onProgress?: (event: ProgressEvent) => void,
+  onText?: (text: string) => Promise<void>,
   agent?: Agent,
   isDelegation?: boolean,
 ): Promise<'success' | 'error'> {
@@ -1087,6 +1128,7 @@ async function runAgent(
         queue.registerProcess(chatJid, proc, containerName, group.folder),
       wrappedOnOutput,
       onProgress,
+      onText,
     );
 
     if (output.status === 'error') {
@@ -1841,18 +1883,25 @@ async function main(): Promise<void> {
           chatJid,
           async (result) => {
             if (result.result) {
-              const raw =
-                typeof result.result === 'string'
-                  ? result.result
-                  : JSON.stringify(result.result);
-              const text = raw
-                .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-                .trim();
-              if (text) {
-                // Set agent name right before sending — parallel delegations
-                // share the same chatJid so we must claim the name each time
-                setActiveAgentName(chatJid, agent.displayName);
-                await channel.sendMessage(chatJid, text);
+              if (
+                result.textsAlreadyStreamed &&
+                result.textsAlreadyStreamed > 0
+              ) {
+                // Text already delivered via intermediate markers
+              } else {
+                const raw =
+                  typeof result.result === 'string'
+                    ? result.result
+                    : JSON.stringify(result.result);
+                const text = raw
+                  .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                  .trim();
+                if (text) {
+                  // Set agent name right before sending — parallel delegations
+                  // share the same chatJid so we must claim the name each time
+                  setActiveAgentName(chatJid, agent.displayName);
+                  await channel.sendMessage(chatJid, text);
+                }
               }
             }
             // Delegation containers exit on their own (isDelegation skips
@@ -1865,6 +1914,14 @@ async function main(): Promise<void> {
             }
           },
           (event) => broadcastProgress(chatJid, event),
+          async (rawText) => {
+            const text = rawText
+              .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+              .trim();
+            if (!text) return;
+            setActiveAgentName(chatJid, agent.displayName);
+            await channel.sendMessage(chatJid, text);
+          },
           agent,
           true, // isDelegation — use shorter timeout
         );

--- a/web/js/components/blocks/CodeBlock.js
+++ b/web/js/components/blocks/CodeBlock.js
@@ -1,7 +1,9 @@
 import { html } from 'htm/preact';
 import { useRef, useEffect, useState } from 'preact/hooks';
 
-export function CodeBlock({ content, language, filename }) {
+export function CodeBlock({ content, code, language, filename }) {
+  // Accept both "content" and "code" — agents may use either field name
+  content = content || code || '';
   const codeRef = useRef(null);
   const [copied, setCopied] = useState(false);
 


### PR DESCRIPTION
## Summary

- **Stream intermediate text blocks**: Agent text produced between tool calls was invisible — only the final SDK result reached users. Adds `NANOCLAW_TEXT` markers that emit each text block in real-time. The host parses these and delivers them as separate messages via `sendMessage`. Final result is skipped when texts were already streamed, preventing duplicates.
- **CodeBlock prop fix**: Agents naturally use `"code"` as the field name for code blocks, but the renderer only accepted `"content"` — causing empty renders. Now accepts both.
- **Credential proxy crash fix**: Invalid URLs in the `/forward` handler caused uncaught exceptions that crashed the proxy. Added try-catch with 400 response. Also fixes stale session loop detection.
- **Internal tag stripping warning**: Logs a warning when `<internal>` tag removal strips all agent output, leaving the user with an empty message.

## Test plan

- [ ] Send a message to an agent that triggers a long response with tool calls (e.g. weekly update draft) — intermediate text should appear as separate messages while agent is still working
- [ ] Final "done" message should not duplicate the already-streamed content
- [ ] Code blocks with `"code"` field in `:::blocks` JSON render correctly
- [ ] Credential proxy handles malformed URLs without crashing
- [ ] Check logs for `<internal>` stripping warnings when agents wrap content incorrectly

🤖 Generated with [Claude Code](https://claude.com/claude-code)