### PR TITLE
feat: credential proxy enhancements, cred-exec, text streaming fixes

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -53,6 +53,7 @@ interface ContainerOutput {
   newSessionId?: string;
   error?: string;
   usage?: UsageData;
+  textsAlreadyStreamed?: number;
 }
 
 interface SessionEntry {
@@ -132,6 +133,8 @@ const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 const PROGRESS_START_MARKER = '---NANOCLAW_PROGRESS_START---';
 const PROGRESS_END_MARKER = '---NANOCLAW_PROGRESS_END---';
+const TEXT_START_MARKER = '---NANOCLAW_TEXT_START---';
+const TEXT_END_MARKER = '---NANOCLAW_TEXT_END---';
 
 interface ProgressEvent {
   tool?: string;
@@ -149,6 +152,12 @@ function writeProgress(event: ProgressEvent): void {
   console.log(PROGRESS_START_MARKER);
   console.log(JSON.stringify(event));
   console.log(PROGRESS_END_MARKER);
+}
+
+function writeText(text: string): void {
+  console.log(TEXT_START_MARKER);
+  console.log(JSON.stringify({ text, timestamp: new Date().toISOString() }));
+  console.log(TEXT_END_MARKER);
 }
 
 function log(message: string): void {
@@ -546,6 +555,7 @@ async function runQuery(
         for (const block of assistantMsg.message.content) {
           if (block.type === 'text' && block.text) {
             assistantTexts.push(block.text);
+            writeText(block.text);
           }
           if (block.type === 'tool_use' && block.name) {
             const summary = summarizeTool(block.name, block.input);
@@ -602,6 +612,7 @@ async function runQuery(
         result: textResult || null,
         newSessionId,
         usage: accumulatedUsage,
+        textsAlreadyStreamed: assistantTexts.length,
       });
       // Reset retry counter on successful text output
       if (textResult) {
@@ -618,17 +629,16 @@ async function runQuery(
   ipcPolling = false;
   log(`Query done. Messages: ${messageCount}, results: ${resultCount}, lastAssistantUuid: ${lastAssistantUuid || 'none'}, closedDuringQuery: ${closedDuringQuery}`);
 
-  // If no result was emitted but we have assistant text, send it as the result
-  // This handles cases where the agent uses interactive elements (action buttons, rich blocks)
-  // and the SDK doesn't generate a result message because it's waiting for user input
+  // If no result was emitted but we have assistant text, send completion.
+  // Text was already streamed via writeText markers — just emit usage/session.
   if (resultCount === 0 && assistantTexts.length > 0) {
-    const combinedText = assistantTexts.join('\n\n');
-    log(`No result message received, using collected assistant text (${combinedText.length} chars)`);
+    log(`No result message received, ${assistantTexts.length} text blocks already streamed`);
     writeOutput({
       status: 'success',
-      result: combinedText,
+      result: null,
       newSessionId,
       usage: accumulatedUsage,
+      textsAlreadyStreamed: assistantTexts.length,
     });
   }
 

--- a/container/scripts/cred-exec.sh
+++ b/container/scripts/cred-exec.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Execute a command with a credential injected as an environment variable.
+#
+# Usage: cred-exec.sh <service> <env_var> -- <command...>
+#
+# Fetches the real credential for <service> from the credential proxy and
+# sets it as <env_var> for the duration of <command>. The credential only
+# exists in the child process's environment — never on disk or in the
+# container's global env.
+#
+# Examples:
+#   cred-exec.sh github GITHUB_TOKEN -- gh pr list
+#   cred-exec.sh github GITHUB_TOKEN -- gh repo clone owner/repo
+#   cred-exec.sh gitlab GITLAB_TOKEN -- glab mr list
+#   cred-exec.sh aws AWS_SECRET_ACCESS_KEY -- aws s3 ls
+#
+# The proxy resolves the service name to the best matching credential
+# (e.g., "github" → GITHUB_TOKEN, "atlassian" → ATLASSIAN_API_TOKEN).
+#
+# Exit codes:
+#   0   — command succeeded
+#   1   — usage error or credential fetch failed
+#   *   — exit code from the wrapped command
+
+set -euo pipefail
+
+if [ $# -lt 4 ]; then
+  echo "Usage: cred-exec.sh <service> <env_var> -- <command...>" >&2
+  exit 1
+fi
+
+SERVICE="$1"
+ENV_VAR="$2"
+shift 2
+
+# Consume the "--" separator
+if [ "$1" != "--" ]; then
+  echo "Error: expected '--' separator after env_var" >&2
+  echo "Usage: cred-exec.sh <service> <env_var> -- <command...>" >&2
+  exit 1
+fi
+shift
+
+if [ $# -eq 0 ]; then
+  echo "Error: no command specified after '--'" >&2
+  exit 1
+fi
+
+# Resolve proxy URL — CRED_PROXY_URL is set by the container runner
+PROXY_URL="${CRED_PROXY_URL:-}"
+if [ -z "$PROXY_URL" ]; then
+  echo "Error: CRED_PROXY_URL not set — are you running inside a container?" >&2
+  exit 1
+fi
+
+# Fetch the real credential from the proxy
+CRED_VALUE=$(curl -sf "${PROXY_URL}/credential/${SERVICE}" 2>/dev/null) || {
+  echo "Error: failed to fetch credential for service '${SERVICE}'" >&2
+  echo "Check that the credential is registered (use request_credential if needed)" >&2
+  exit 1
+}
+
+if [ -z "$CRED_VALUE" ]; then
+  echo "Error: empty credential returned for service '${SERVICE}'" >&2
+  exit 1
+fi
+
+# Execute the command with the credential injected
+export "${ENV_VAR}=${CRED_VALUE}"
+exec "$@"

--- a/container/scripts/cred-exec.sh
+++ b/container/scripts/cred-exec.sh
@@ -54,14 +54,22 @@ if [ -z "$PROXY_URL" ]; then
 fi
 
 # Fetch the real credential from the proxy
-CRED_VALUE=$(curl -sf "${PROXY_URL}/credential/${SERVICE}" 2>/dev/null) || {
-  echo "Error: failed to fetch credential for service '${SERVICE}'" >&2
-  echo "Check that the credential is registered (use request_credential if needed)" >&2
+HTTP_CODE=$(curl -s -o /tmp/.cred-exec-response -w "%{http_code}" "${PROXY_URL}/credential/${SERVICE}" 2>/dev/null) || {
+  echo "Error: could not reach credential proxy at ${PROXY_URL}" >&2
+  echo "Is ClawDad running? Check the service status." >&2
   exit 1
 }
 
-if [ -z "$CRED_VALUE" ]; then
-  echo "Error: empty credential returned for service '${SERVICE}'" >&2
+CRED_VALUE=$(cat /tmp/.cred-exec-response 2>/dev/null)
+rm -f /tmp/.cred-exec-response
+
+if [ "$HTTP_CODE" != "200" ] || [ -z "$CRED_VALUE" ]; then
+  # The proxy returns a helpful text error — pass it through
+  echo "Error: credential lookup failed for service '${SERVICE}' (HTTP ${HTTP_CODE})" >&2
+  if [ -n "$CRED_VALUE" ]; then
+    echo "" >&2
+    echo "$CRED_VALUE" >&2
+  fi
   exit 1
 fi
 

--- a/container/skills/credential-proxy/SKILL.md
+++ b/container/skills/credential-proxy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: credential-proxy
-description: How to make authenticated API calls to external services. Covers api.sh, auth patterns, available credentials, cloning repos, and troubleshooting 401s. Read this before calling any external API.
+description: How to make authenticated API calls to external services. Covers api.sh, cred-exec, auth patterns, available credentials, cloning repos, SSH forwarding, and troubleshooting 401s. Read this before calling any external API or using a CLI tool that needs auth.
 ---
 
 # Credential Proxy — Authenticated API Access
@@ -9,13 +9,53 @@ All external API calls go through the credential proxy via `/workspace/scripts/a
 
 ## The One Rule
 
-**ALWAYS use `/workspace/scripts/api.sh`** for authenticated requests. Never use raw `curl`, `gh`, `git clone` with SSH, or any other tool that bypasses the proxy.
+**ALWAYS use `/workspace/scripts/api.sh`** for authenticated HTTP requests. Never use raw `curl`, `gh`, `git clone` with SSH, or any other tool that bypasses the proxy — unless you wrap it with `cred-exec.sh` (see below).
 
 ```bash
 /workspace/scripts/api.sh <service_label> <METHOD> <URL> [CURL_ARGS...]
 ```
 
 The first argument is a service label (for logging). The rest is passed to `curl`.
+
+## CLI Tools — `cred-exec`
+
+For CLI tools that need credentials (like `gh`, `glab`, `aws`, etc.), use `cred-exec.sh` to inject a real credential for the duration of a single command:
+
+```bash
+/workspace/scripts/cred-exec.sh <service> <env_var> -- <command...>
+```
+
+This fetches the real credential from the proxy and sets it as `<env_var>` only for the child process. The credential never touches disk or the container's global environment.
+
+### Examples
+
+```bash
+# GitHub CLI
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- gh pr list
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- gh repo clone owner/repo
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- gh issue view 123
+
+# GitLab CLI
+/workspace/scripts/cred-exec.sh gitlab GITLAB_TOKEN -- glab mr list
+
+# Any CLI tool that reads auth from an env var
+/workspace/scripts/cred-exec.sh myservice MY_API_KEY -- some-cli --flag
+```
+
+### How it works
+
+1. `cred-exec.sh` calls the credential proxy's `/credential/<service>` endpoint
+2. The proxy looks up the best matching credential in `.env` (e.g., `github` → `GITHUB_TOKEN`)
+3. The real value is set as the specified env var for the wrapped command
+4. The command runs and exits — credential exists only in that process's memory
+
+### When to use `api.sh` vs `cred-exec.sh`
+
+| Scenario | Tool |
+|----------|------|
+| HTTP API calls (REST, GraphQL) | `api.sh` |
+| CLI tools (`gh`, `glab`, `aws`, `jira`, etc.) | `cred-exec.sh` |
+| `git clone` / `git push` over HTTPS | `cred-exec.sh` (see Cloning Repositories below) |
 
 ## Available Services
 
@@ -30,29 +70,24 @@ env | grep -E '_(TOKEN|KEY|SECRET|URL|EMAIL)=' | sed 's/=.*//' | sort
 ### GitHub
 
 ```bash
-# List repos
+# API calls
 /workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO" \
   -H "Authorization: token $GITHUB_TOKEN"
 
-# Read file contents
-/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/PATH" \
-  -H "Authorization: token $GITHUB_TOKEN"
-
-# List PRs
-/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/pulls?state=open" \
-  -H "Authorization: token $GITHUB_TOKEN"
+# CLI tool
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- gh pr list
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- gh repo clone owner/repo
 ```
 
 ### GitLab
 
 ```bash
-# List projects
+# API calls
 /workspace/scripts/api.sh gitlab GET "$GITLAB_URL/api/v4/projects?membership=true" \
   -H "PRIVATE-TOKEN: $GITLAB_TOKEN"
 
-# List merge requests
-/workspace/scripts/api.sh gitlab GET "$GITLAB_URL/api/v4/projects/PROJECT_ID/merge_requests?state=opened" \
-  -H "PRIVATE-TOKEN: $GITLAB_TOKEN"
+# CLI tool
+/workspace/scripts/cred-exec.sh gitlab GITLAB_TOKEN -- glab mr list
 ```
 
 ### Atlassian (Jira / Confluence)
@@ -106,27 +141,47 @@ Use any label — the proxy doesn't restrict service names:
 ```bash
 /workspace/scripts/api.sh my-service GET "https://api.example.com/endpoint" \
   -H "Authorization: Bearer $MY_SERVICE_TOKEN"
+
+# Or with cred-exec for a CLI tool
+/workspace/scripts/cred-exec.sh my-service MY_SERVICE_TOKEN -- some-tool
 ```
 
 ## Cloning Repositories
 
-**Do NOT use `git clone` with SSH** — your container has no SSH keys.
+### HTTPS clone with `cred-exec`
 
-Options:
-1. **GitHub API** — read files directly (best for a few files):
-   ```bash
-   /workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/path/to/file" \
-     -H "Authorization: token $GITHUB_TOKEN" | jq -r '.content' | base64 -d
-   ```
+The easiest way to clone a full repo:
 
-2. **HTTPS clone with token** — for full repo access:
-   ```bash
-   git clone https://x-access-token:${GITHUB_TOKEN}@github.com/OWNER/REPO.git /workspace/group/repo-name
-   ```
-   Note: The `$GITHUB_TOKEN` placeholder won't be substituted in `git clone` (it doesn't go through the proxy). If you need to clone, ask the user to provide the local path and mount it via `containerConfig.additionalMounts`.
+```bash
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- \
+  git clone https://x-access-token:${GITHUB_TOKEN}@github.com/OWNER/REPO.git /workspace/group/repo-name
+```
 
-3. **Ask for a local mount** — if the user has the repo on their machine:
-   > I can't clone repos directly from inside my container. Could you tell me the local path to the repo? I'll set it up as an additional mount.
+Note: `cred-exec` sets the real `GITHUB_TOKEN` value, so the `${GITHUB_TOKEN}` in the URL resolves to the real token within the child process.
+
+### GitHub API (for a few files)
+
+```bash
+/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/path/to/file" \
+  -H "Authorization: token $GITHUB_TOKEN" | jq -r '.content' | base64 -d
+```
+
+### SSH clone (requires `sshAgent` opt-in)
+
+If the group has `containerConfig.sshAgent: true` and the host has `SSH_AUTH_SOCK` set, the host's SSH agent socket is forwarded into the container. This allows SSH operations without the private key entering the container:
+
+```bash
+git clone git@github.com:OWNER/REPO.git /workspace/group/repo-name
+ssh user@host "command"
+```
+
+The agent cannot be configured from within the container — it only provides access to keys already loaded on the host.
+
+### Ask for a local mount
+
+If the user has the repo on their machine:
+
+> I can't clone repos directly from inside my container. Could you tell me the local path to the repo? I'll set it up as an additional mount.
 
 ## Registering New Credentials
 
@@ -144,17 +199,19 @@ This opens a popup in the user's browser. The credential is available immediatel
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| 401 Unauthorized | Not using `api.sh` | Switch from raw `curl` to `api.sh` |
+| 401 Unauthorized | Not using `api.sh` or `cred-exec` | Switch from raw `curl`/`gh` to `api.sh` or `cred-exec.sh` |
 | 401 Unauthorized | Missing auth header | Add `-H "Authorization: token $TOKEN"` or equivalent |
 | 401 Unauthorized | Credential expired/missing | Use `request_credential` to re-register |
 | 410 Gone | Deprecated Jira endpoint | Use `/rest/api/3/search/jql` POST instead of `/rest/api/3/search` GET |
 | Connection refused | Wrong base URL | Check `env \| grep _URL` for the correct service URL |
 | Empty response | Placeholder not substituted | Verify the env var name matches exactly (case-sensitive) |
+| `cred-exec` fails | CRED_PROXY_URL not set | You're likely not in a container — use `api.sh` on the host |
 
 ## Key Rules
 
-1. **Always `api.sh`** — never raw `curl` for authenticated calls
-2. **Always pass auth headers** — the proxy substitutes placeholders, it doesn't add headers
-3. **Never echo credentials** — env vars contain placeholders, but don't log them anyway
-4. **Never ask users to paste tokens** — use `request_credential` instead
-5. **Try first, ask second** — attempt the API call before requesting new credentials
+1. **Always `api.sh`** — never raw `curl` for authenticated HTTP calls
+2. **Always `cred-exec.sh`** — for CLI tools that need credentials (`gh`, `glab`, etc.)
+3. **Always pass auth headers** — the proxy substitutes placeholders, it doesn't add headers
+4. **Never echo credentials** — env vars contain placeholders, but don't log them anyway
+5. **Never ask users to paste tokens** — use `request_credential` instead
+6. **Try first, ask second** — attempt the API call before requesting new credentials

--- a/container/skills/credential-proxy/SKILL.md
+++ b/container/skills/credential-proxy/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: credential-proxy
+description: How to make authenticated API calls to external services. Covers api.sh, auth patterns, available credentials, cloning repos, and troubleshooting 401s. Read this before calling any external API.
+---
+
+# Credential Proxy — Authenticated API Access
+
+All external API calls go through the credential proxy via `/workspace/scripts/api.sh`. The proxy injects real credentials at request time — your environment variables contain **placeholders**, not real secrets.
+
+## The One Rule
+
+**ALWAYS use `/workspace/scripts/api.sh`** for authenticated requests. Never use raw `curl`, `gh`, `git clone` with SSH, or any other tool that bypasses the proxy.
+
+```bash
+/workspace/scripts/api.sh <service_label> <METHOD> <URL> [CURL_ARGS...]
+```
+
+The first argument is a service label (for logging). The rest is passed to `curl`.
+
+## Available Services
+
+Check what's configured in your container:
+
+```bash
+env | grep -E '_(TOKEN|KEY|SECRET|URL|EMAIL)=' | sed 's/=.*//' | sort
+```
+
+## Auth Patterns by Service
+
+### GitHub
+
+```bash
+# List repos
+/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO" \
+  -H "Authorization: token $GITHUB_TOKEN"
+
+# Read file contents
+/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/PATH" \
+  -H "Authorization: token $GITHUB_TOKEN"
+
+# List PRs
+/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/pulls?state=open" \
+  -H "Authorization: token $GITHUB_TOKEN"
+```
+
+### GitLab
+
+```bash
+# List projects
+/workspace/scripts/api.sh gitlab GET "$GITLAB_URL/api/v4/projects?membership=true" \
+  -H "PRIVATE-TOKEN: $GITLAB_TOKEN"
+
+# List merge requests
+/workspace/scripts/api.sh gitlab GET "$GITLAB_URL/api/v4/projects/PROJECT_ID/merge_requests?state=opened" \
+  -H "PRIVATE-TOKEN: $GITLAB_TOKEN"
+```
+
+### Atlassian (Jira / Confluence)
+
+**IMPORTANT:** `/rest/api/3/search` is deprecated (returns 410). Use `/rest/api/3/search/jql` with POST instead.
+
+```bash
+INSTANCE="$ATLASSIAN_BASE_URL"
+
+# Search Jira issues (POST — required for /search/jql)
+/workspace/scripts/api.sh atlassian POST "${INSTANCE}/rest/api/3/search/jql" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -u "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN" \
+  -d '{"jql": "project = PROJ AND assignee = currentUser() ORDER BY updated DESC", "fields": ["summary", "status", "updated"], "maxResults": 20}'
+
+# Get a single issue
+/workspace/scripts/api.sh atlassian GET "${INSTANCE}/rest/api/3/issue/PROJ-123" \
+  -u "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN"
+
+# Read a Confluence page
+/workspace/scripts/api.sh atlassian GET "${INSTANCE}/wiki/rest/api/content/PAGE_ID?expand=body.storage" \
+  -u "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN"
+```
+
+### Harness
+
+```bash
+/workspace/scripts/api.sh harness GET "https://app.harness.io/ng/api/..." \
+  -H "x-api-key: $HARNESS_API_KEY"
+```
+
+### LaunchDarkly
+
+```bash
+/workspace/scripts/api.sh launchdarkly GET "https://app.launchdarkly.com/api/v2/flags/PROJECT_KEY" \
+  -H "Authorization: $LAUNCHDARKLY_API_KEY"
+```
+
+### BlackDuck
+
+```bash
+/workspace/scripts/api.sh blackduck GET "$BLACKDUCK_URL/api/..." \
+  -H "Authorization: token $BLACKDUCK_API_TOKEN"
+```
+
+### Custom / Other Services
+
+Use any label — the proxy doesn't restrict service names:
+
+```bash
+/workspace/scripts/api.sh my-service GET "https://api.example.com/endpoint" \
+  -H "Authorization: Bearer $MY_SERVICE_TOKEN"
+```
+
+## Cloning Repositories
+
+**Do NOT use `git clone` with SSH** — your container has no SSH keys.
+
+Options:
+1. **GitHub API** — read files directly (best for a few files):
+   ```bash
+   /workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/path/to/file" \
+     -H "Authorization: token $GITHUB_TOKEN" | jq -r '.content' | base64 -d
+   ```
+
+2. **HTTPS clone with token** — for full repo access:
+   ```bash
+   git clone https://x-access-token:${GITHUB_TOKEN}@github.com/OWNER/REPO.git /workspace/group/repo-name
+   ```
+   Note: The `$GITHUB_TOKEN` placeholder won't be substituted in `git clone` (it doesn't go through the proxy). If you need to clone, ask the user to provide the local path and mount it via `containerConfig.additionalMounts`.
+
+3. **Ask for a local mount** — if the user has the repo on their machine:
+   > I can't clone repos directly from inside my container. Could you tell me the local path to the repo? I'll set it up as an additional mount.
+
+## Registering New Credentials
+
+If a service returns 401 and you've confirmed you're using `api.sh` with the right auth header:
+
+```
+Use mcp__nanoclaw__request_credential with:
+- service: "service-name"
+- description: "Why this credential is needed"
+```
+
+This opens a popup in the user's browser. The credential is available immediately — no restart needed. A `[credential_registered]` message appears in chat when complete.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 401 Unauthorized | Not using `api.sh` | Switch from raw `curl` to `api.sh` |
+| 401 Unauthorized | Missing auth header | Add `-H "Authorization: token $TOKEN"` or equivalent |
+| 401 Unauthorized | Credential expired/missing | Use `request_credential` to re-register |
+| 410 Gone | Deprecated Jira endpoint | Use `/rest/api/3/search/jql` POST instead of `/rest/api/3/search` GET |
+| Connection refused | Wrong base URL | Check `env \| grep _URL` for the correct service URL |
+| Empty response | Placeholder not substituted | Verify the env var name matches exactly (case-sensitive) |
+
+## Key Rules
+
+1. **Always `api.sh`** — never raw `curl` for authenticated calls
+2. **Always pass auth headers** — the proxy substitutes placeholders, it doesn't add headers
+3. **Never echo credentials** — env vars contain placeholders, but don't log them anyway
+4. **Never ask users to paste tokens** — use `request_credential` instead
+5. **Try first, ask second** — attempt the API call before requesting new credentials

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -20,6 +20,8 @@ Wrap internal reasoning in `<internal>` tags — it's logged but not sent:
 Here's what I found...
 ```
 
+**CRITICAL:** Only use `<internal>` for brief reasoning notes (plan-of-action, self-reminders). NEVER wrap content meant for the user — drafts, summaries, reports, :::blocks, code output, or any deliverable — in `<internal>` tags. Everything inside `<internal>` is **permanently stripped** before delivery. If you compile a draft and then say "it's above," but the draft was inside `<internal>` tags, the user will see nothing.
+
 ### Sub-agents and teammates
 
 When working as a sub-agent or teammate, only use `send_message` if instructed by the main agent.

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -105,67 +105,20 @@ The `conversations/` folder contains searchable markdown snapshots of past sessi
 - Remove memories that are no longer true
 - Keep `MEMORY.md` under 50 lines
 
-## Credential Registration
+## API Access & Credentials
 
-If you need API credentials for a service, use the `mcp__nanoclaw__request_credential` tool. It opens a secure popup in the user's browser — you never see the secret.
+**All external API calls MUST go through `/workspace/scripts/api.sh`** — it routes through the credential proxy which injects real secrets at request time. Your environment variables contain placeholders, not real secrets. Never use raw `curl`, `gh` CLI, or `git clone` with SSH.
 
-**CRITICAL: Never ask users to paste secrets, API keys, or tokens in chat.** Always use `request_credential`.
+The `credential-proxy` skill has full documentation: auth patterns for every service, repo cloning, troubleshooting 401s, and examples. Read it before making any API call.
 
-```
-Use mcp__nanoclaw__request_credential with:
-- service: "github" (or "atlassian", "gitlab", "launchdarkly", or a custom name)
-- description: "Why this credential is needed — shown to the user in the popup"
-```
-
-The tool returns immediately — it does NOT block waiting for the user. The flow is:
-1. Tool opens a popup in the user's browser
-2. Tool returns right away — continue with other work
-3. User enters their secret in the form (you never see it)
-4. Secret is saved and available immediately via the credential proxy — no restart needed
-5. A `[credential_registered]` message appears in the chat — that's your signal to proceed
-
-### Using registered credentials
-
-Credentials are injected by the credential proxy. Always use `/workspace/scripts/api.sh` for service API calls — it routes through the proxy automatically:
-
+**Quick reference:**
 ```bash
 /workspace/scripts/api.sh <service_label> <METHOD> <URL> [CURL_ARGS...]
 ```
 
-The first argument is a **service label** — a short name for logging and error tracking. Common labels: `github`, `gitlab`, `atlassian`, `harness`, `blackduck`, `launchdarkly`. Use any label for custom services.
+You MUST pass auth headers explicitly — the proxy substitutes placeholder values but doesn't add headers for you.
 
-**How auth works:** Your environment variables (e.g. `$GITHUB_TOKEN`, `$ATLASSIAN_API_TOKEN`) contain **placeholders**, not real secrets. The credential proxy substitutes real values at request time. You MUST pass auth headers/flags explicitly on every call — the proxy only replaces the placeholder values, it doesn't add headers for you.
-
-**Common auth patterns:**
-```bash
-# Bearer token:  -H "Authorization: token $SERVICE_TOKEN"
-# Private token: -H "PRIVATE-TOKEN: $SERVICE_TOKEN"
-# Basic auth:    -u "$SERVICE_EMAIL:$SERVICE_API_TOKEN"
-# API key:       -H "x-api-key: $SERVICE_API_KEY"
-```
-
-The proxy replaces credential placeholders with real values at request time. Newly registered credentials work immediately — no container restart needed.
-
-**IMPORTANT: Try the API call first** using `api.sh`. If the call returns 401, THEN use `request_credential` to ask the user.
-
-**Do NOT use `gh` CLI or raw `curl` for authenticated requests** — use `api.sh` so credentials are injected by the proxy.
-
-**Security rules:**
-- NEVER ask the user to paste tokens, keys, or passwords in chat
-- NEVER echo, log, or print credential values — they contain placeholders, not real secrets
-- NEVER use raw curl for authenticated API calls — always use `api.sh`
-- If an API call fails with 401/403, call `request_credential` — the token may have expired
-
-### Service-specific configuration
-
-Service URLs and auth details are provided as environment variables. Check what's available with `env | grep -E '(URL|EMAIL|ACCOUNT)' | sort` — this shows base URLs, emails, and account IDs for connected services. Your group's CLAUDE.md should document specific API endpoints and patterns relevant to your domain.
-
-### API pitfalls to avoid
-
-- **Deprecated endpoints:** Some service APIs deprecate endpoints over time (returning 410 Gone). If you get a 410, check the service's current API docs for the replacement endpoint. Do not retry the same URL.
-- **URL encoding in GET queries:** URL-encode JQL, CQL, or other query strings. Use `--data-urlencode` for complex query params or switch to POST with a JSON body.
-- **Rate limits:** If you get 429 responses, back off and retry with increasing delays. Log the rate limit event.
-- **Pagination:** Most APIs return paginated results. Check for `nextPage`, `startAt`/`total`, or `cursor` fields in responses and paginate as needed.
+**Requesting new credentials:** Use `mcp__nanoclaw__request_credential` — it opens a secure popup in the user's browser. Never ask users to paste secrets in chat. Try the API call first; only request credentials if you get a 401.
 
 ## Event Logging
 

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -22,6 +22,23 @@ Here's what I found...
 
 **CRITICAL:** Only use `<internal>` for brief reasoning notes (plan-of-action, self-reminders). NEVER wrap content meant for the user — drafts, summaries, reports, :::blocks, code output, or any deliverable — in `<internal>` tags. Everything inside `<internal>` is **permanently stripped** before delivery. If you compile a draft and then say "it's above," but the draft was inside `<internal>` tags, the user will see nothing.
 
+### Message delivery — what the user actually sees
+
+**Only your FINAL text output is delivered to the user.** Text you produce between tool calls is part of your reasoning chain but is NOT sent. If you write a long draft, then make tool calls (logging, saving files), and then say "the draft is above" — the user only sees "the draft is above." The draft itself is lost.
+
+**Rules:**
+1. **All user-facing content must be in your final response** — the last text you produce after all tool calls are done. Do not make tool calls after writing content meant for the user.
+2. **If you need to do work after producing content**, use `mcp__nanoclaw__send_message` to deliver the content first, then continue with tool calls. `send_message` delivers immediately regardless of what happens after.
+3. **Never say "see above" or "the draft is above"** unless you used `send_message` to deliver it. If it's in your final response, say "here's the draft" — not "above."
+
+**Pattern — long content with follow-up work:**
+```
+1. Do all research/tool calls first
+2. Use send_message to deliver the main content
+3. Do any follow-up work (logging, saving files)
+4. Final response: brief acknowledgment only
+```
+
 ### Sub-agents and teammates
 
 When working as a sub-agent or teammate, only use `send_message` if instructed by the main agent.
@@ -112,21 +129,19 @@ The tool returns immediately — it does NOT block waiting for the user. The flo
 Credentials are injected by the credential proxy. Always use `/workspace/scripts/api.sh` for service API calls — it routes through the proxy automatically:
 
 ```bash
-# GitHub
-/workspace/scripts/api.sh github GET "https://api.github.com/user" \
-  -H "Authorization: token $GITHUB_TOKEN"
+/workspace/scripts/api.sh <service_label> <METHOD> <URL> [CURL_ARGS...]
+```
 
-# GitLab
-/workspace/scripts/api.sh gitlab GET "https://gitlab.com/api/v4/projects" \
-  -H "PRIVATE-TOKEN: $GITLAB_TOKEN"
+The first argument is a **service label** — a short name for logging and error tracking. Common labels: `github`, `gitlab`, `atlassian`, `harness`, `blackduck`, `launchdarkly`. Use any label for custom services.
 
-# Atlassian
-/workspace/scripts/api.sh atlassian GET "https://yourorg.atlassian.net/rest/api/3/myself" \
-  -u "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN"
+**How auth works:** Your environment variables (e.g. `$GITHUB_TOKEN`, `$ATLASSIAN_API_TOKEN`) contain **placeholders**, not real secrets. The credential proxy substitutes real values at request time. You MUST pass auth headers/flags explicitly on every call — the proxy only replaces the placeholder values, it doesn't add headers for you.
 
-# Custom services — the env var name matches what was registered
-/workspace/scripts/api.sh myservice GET "https://api.example.com/data" \
-  -H "Authorization: Bearer $MYSERVICE_TOKEN"
+**Common auth patterns:**
+```bash
+# Bearer token:  -H "Authorization: token $SERVICE_TOKEN"
+# Private token: -H "PRIVATE-TOKEN: $SERVICE_TOKEN"
+# Basic auth:    -u "$SERVICE_EMAIL:$SERVICE_API_TOKEN"
+# API key:       -H "x-api-key: $SERVICE_API_KEY"
 ```
 
 The proxy replaces credential placeholders with real values at request time. Newly registered credentials work immediately — no container restart needed.
@@ -140,6 +155,17 @@ The proxy replaces credential placeholders with real values at request time. New
 - NEVER echo, log, or print credential values — they contain placeholders, not real secrets
 - NEVER use raw curl for authenticated API calls — always use `api.sh`
 - If an API call fails with 401/403, call `request_credential` — the token may have expired
+
+### Service-specific configuration
+
+Service URLs and auth details are provided as environment variables. Check what's available with `env | grep -E '(URL|EMAIL|ACCOUNT)' | sort` — this shows base URLs, emails, and account IDs for connected services. Your group's CLAUDE.md should document specific API endpoints and patterns relevant to your domain.
+
+### API pitfalls to avoid
+
+- **Deprecated endpoints:** Some service APIs deprecate endpoints over time (returning 410 Gone). If you get a 410, check the service's current API docs for the replacement endpoint. Do not retry the same URL.
+- **URL encoding in GET queries:** URL-encode JQL, CQL, or other query strings. Use `--data-urlencode` for complex query params or switch to POST with a JSON body.
+- **Rate limits:** If you get 429 responses, back off and retry with increasing delays. Log the rate limit event.
+- **Pagination:** Most APIs return paginated results. Check for `nextPage`, `startAt`/`total`, or `cursor` fields in responses and paginate as needed.
 
 ## Event Logging
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -66,7 +66,7 @@ This is the **main channel** with elevated privileges.
 
 ## API Access & Credentials
 
-You have access to multiple services through the credential proxy. **NEVER use raw `curl`, `git clone` with SSH, or `gh` CLI** — always use `/workspace/scripts/api.sh` which routes through the proxy and injects real credentials automatically.
+You have access to multiple services through the credential proxy. **NEVER use raw `curl`** — use `/workspace/scripts/api.sh` for HTTP API calls and `/workspace/scripts/cred-exec.sh` for CLI tools (`gh`, `glab`, etc.).
 
 Your environment variables (`$GITHUB_TOKEN`, `$ATLASSIAN_API_TOKEN`, etc.) contain **placeholders**, not real secrets. The proxy substitutes them at request time. You MUST pass auth headers explicitly.
 
@@ -81,16 +81,28 @@ Your environment variables (`$GITHUB_TOKEN`, `$ATLASSIAN_API_TOKEN`, etc.) conta
 | LaunchDarkly | `/workspace/scripts/api.sh launchdarkly GET "https://app.launchdarkly.com/api/v2/..." -H "Authorization: $LAUNCHDARKLY_API_KEY"` |
 | BlackDuck | `/workspace/scripts/api.sh blackduck GET "$BLACKDUCK_URL/api/..." -H "Authorization: token $BLACKDUCK_API_TOKEN"` |
 
+### CLI tools (gh, glab, etc.)
+
+```bash
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- gh pr list
+/workspace/scripts/cred-exec.sh gitlab GITLAB_TOKEN -- glab mr list
+```
+
 ### Cloning repos
 
-**Do NOT use `git clone` with SSH** — your container has no SSH keys. Instead:
-- Use the GitHub API to read repo contents: `/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/PATH"`
-- Or ask the user to provide the local path and mount it via `containerConfig.additionalMounts`
-- For bulk file reads, clone via HTTPS with token: `git clone https://x-access-token:$GITHUB_TOKEN@github.com/OWNER/REPO.git` (this also goes through the proxy)
+```bash
+# HTTPS clone with cred-exec
+/workspace/scripts/cred-exec.sh github GITHUB_TOKEN -- \
+  git clone https://x-access-token:${GITHUB_TOKEN}@github.com/OWNER/REPO.git /workspace/group/repo
+
+# Or read individual files via API
+/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/PATH" \
+  -H "Authorization: token $GITHUB_TOKEN"
+```
 
 ### If you get a 401
 
-1. Check you're using `api.sh`, not raw `curl`
+1. Check you're using `api.sh` or `cred-exec.sh`, not raw `curl`/`gh`
 2. Check you're passing the auth header/flag
 3. If still failing, use `mcp__nanoclaw__request_credential` to re-register the credential
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -64,9 +64,35 @@ When you learn something important:
 
 This is the **main channel** with elevated privileges.
 
-## Authentication
+## API Access & Credentials
 
-Anthropic credentials are resolved automatically from Claude Code's credential store (`~/.claude/.credentials.json`), with `.env` as fallback. The credential proxy handles injection — see `src/credential-proxy.ts`. Service credentials use `api.sh` which routes through the proxy's `/forward` endpoint.
+You have access to multiple services through the credential proxy. **NEVER use raw `curl`, `git clone` with SSH, or `gh` CLI** — always use `/workspace/scripts/api.sh` which routes through the proxy and injects real credentials automatically.
+
+Your environment variables (`$GITHUB_TOKEN`, `$ATLASSIAN_API_TOKEN`, etc.) contain **placeholders**, not real secrets. The proxy substitutes them at request time. You MUST pass auth headers explicitly.
+
+### Available services
+
+| Service | Auth pattern |
+|---------|-------------|
+| GitHub | `/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO" -H "Authorization: token $GITHUB_TOKEN"` |
+| GitLab | `/workspace/scripts/api.sh gitlab GET "$GITLAB_URL/api/v4/projects" -H "PRIVATE-TOKEN: $GITLAB_TOKEN"` |
+| Atlassian (Jira/Confluence) | `/workspace/scripts/api.sh atlassian GET "$ATLASSIAN_BASE_URL/rest/api/3/..." -u "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN"` |
+| Harness | `/workspace/scripts/api.sh harness GET "https://app.harness.io/ng/api/..." -H "x-api-key: $HARNESS_API_KEY"` |
+| LaunchDarkly | `/workspace/scripts/api.sh launchdarkly GET "https://app.launchdarkly.com/api/v2/..." -H "Authorization: $LAUNCHDARKLY_API_KEY"` |
+| BlackDuck | `/workspace/scripts/api.sh blackduck GET "$BLACKDUCK_URL/api/..." -H "Authorization: token $BLACKDUCK_API_TOKEN"` |
+
+### Cloning repos
+
+**Do NOT use `git clone` with SSH** — your container has no SSH keys. Instead:
+- Use the GitHub API to read repo contents: `/workspace/scripts/api.sh github GET "https://api.github.com/repos/OWNER/REPO/contents/PATH"`
+- Or ask the user to provide the local path and mount it via `containerConfig.additionalMounts`
+- For bulk file reads, clone via HTTPS with token: `git clone https://x-access-token:$GITHUB_TOKEN@github.com/OWNER/REPO.git` (this also goes through the proxy)
+
+### If you get a 401
+
+1. Check you're using `api.sh`, not raw `curl`
+2. Check you're passing the auth header/flag
+3. If still failing, use `mcp__nanoclaw__request_credential` to re-register the credential
 
 ## Container Mounts
 

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -25,6 +25,7 @@ import { getHealthStatus } from '../health.js';
 import {
   getMessagesSince,
   storeMessageDirect,
+  updateMessageContent,
   clearMessages,
   getAllTasks,
   getTaskById,
@@ -206,30 +207,18 @@ export class WebChannel implements Channel {
     jid: string,
     messageId: string,
     text: string,
-    threadId?: string,
+    _threadId?: string,
   ): Promise<void> {
-    const timestamp = new Date().toISOString();
     const senderName = getActiveAgentName(jid) || ASSISTANT_NAME;
 
-    // Overwrite existing row (INSERT OR REPLACE on id + chat_jid)
-    storeMessageDirect({
-      id: messageId,
-      chat_jid: jid,
-      sender: senderName,
-      sender_name: senderName,
-      content: text,
-      timestamp,
-      is_from_me: true,
-      is_bot_message: true,
-      thread_id: threadId,
-    });
+    // Update content only — preserve original timestamp and rowid so
+    // message order stays stable on page refresh.
+    updateMessageContent(messageId, jid, text);
 
     this.broadcast('message_update', {
       jid,
       message_id: messageId,
       text,
-      timestamp,
-      thread_id: threadId,
       sender_name: senderName,
     });
   }

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -170,7 +170,8 @@ export class WebChannel implements Channel {
     jid: string,
     text: string,
     threadId?: string,
-  ): Promise<void> {
+  ): Promise<string> {
+    const id = randomUUID();
     const timestamp = new Date().toISOString();
 
     // Use active agent name if set (multi-agent groups), else default
@@ -178,7 +179,7 @@ export class WebChannel implements Channel {
 
     // Persist agent response so it survives page reloads
     storeMessageDirect({
-      id: randomUUID(),
+      id,
       chat_jid: jid,
       sender: senderName,
       sender_name: senderName,
@@ -191,12 +192,46 @@ export class WebChannel implements Channel {
 
     this.broadcast('message', {
       jid,
+      message_id: id,
       text,
       timestamp,
       thread_id: threadId,
       sender_name: senderName,
     });
     logger.info({ jid, length: text.length, threadId }, 'Web message sent');
+    return id;
+  }
+
+  async updateMessage(
+    jid: string,
+    messageId: string,
+    text: string,
+    threadId?: string,
+  ): Promise<void> {
+    const timestamp = new Date().toISOString();
+    const senderName = getActiveAgentName(jid) || ASSISTANT_NAME;
+
+    // Overwrite existing row (INSERT OR REPLACE on id + chat_jid)
+    storeMessageDirect({
+      id: messageId,
+      chat_jid: jid,
+      sender: senderName,
+      sender_name: senderName,
+      content: text,
+      timestamp,
+      is_from_me: true,
+      is_bot_message: true,
+      thread_id: threadId,
+    });
+
+    this.broadcast('message_update', {
+      jid,
+      message_id: messageId,
+      text,
+      timestamp,
+      thread_id: threadId,
+      sender_name: senderName,
+    });
   }
 
   async setTyping(

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -303,6 +303,7 @@ async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   isMain: boolean,
+  group?: RegisteredGroup,
 ): Promise<string[]> {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
@@ -357,6 +358,13 @@ async function buildContainerArgs(
     '-e',
     `CRED_PROXY_URL=http://${CONTAINER_HOST_GATEWAY}:${CREDENTIAL_PROXY_PORT}`,
   );
+
+  // SSH agent forwarding — mount host socket so containers can use SSH
+  // without the private key ever entering the container.
+  if (group?.containerConfig?.sshAgent && process.env.SSH_AUTH_SOCK) {
+    const sock = process.env.SSH_AUTH_SOCK;
+    args.push('-v', `${sock}:/ssh-agent`, '-e', 'SSH_AUTH_SOCK=/ssh-agent');
+  }
 
   // Pass model override for LiteLLM proxy routing
   const claudeModel = process.env.CLAUDE_MODEL || allEnv.CLAUDE_MODEL;
@@ -633,6 +641,7 @@ export async function spawnContainer(
     mounts,
     containerName,
     input.isMain,
+    group,
   );
 
   logger.info(

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -36,6 +36,8 @@ const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 const PROGRESS_START_MARKER = '---NANOCLAW_PROGRESS_START---';
 const PROGRESS_END_MARKER = '---NANOCLAW_PROGRESS_END---';
+const TEXT_START_MARKER = '---NANOCLAW_TEXT_START---';
+const TEXT_END_MARKER = '---NANOCLAW_TEXT_END---';
 
 export interface ProgressEvent {
   tool?: string;
@@ -76,6 +78,7 @@ export interface ContainerOutput {
   newSessionId?: string;
   error?: string;
   usage?: UsageData;
+  textsAlreadyStreamed?: number;
 }
 
 interface VolumeMount {
@@ -397,6 +400,7 @@ export async function runContainerAgent(
   onProcess: (proc: ChildProcess, containerName: string) => void,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   onProgress?: (event: ProgressEvent) => void,
+  onText?: (text: string) => Promise<void>,
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
 
@@ -513,8 +517,8 @@ export async function runContainerAgent(
         }
       }
 
-      // Stream-parse for output and progress markers
-      if (onOutput || onProgress) {
+      // Stream-parse for output, progress, and text markers
+      if (onOutput || onProgress || onText) {
         parseBuffer += chunk;
 
         // Parse progress markers (lightweight, no Promise chain)
@@ -537,6 +541,28 @@ export async function runContainerAgent(
               /* ignore malformed progress */
             }
             // Activity detected — reset timeout
+            resetTimeout();
+          }
+        }
+
+        // Parse text markers (async, ordered via outputChain)
+        if (onText) {
+          let textStart: number;
+          while ((textStart = parseBuffer.indexOf(TEXT_START_MARKER)) !== -1) {
+            const textEnd = parseBuffer.indexOf(TEXT_END_MARKER, textStart);
+            if (textEnd === -1) break;
+            const textJson = parseBuffer
+              .slice(textStart + TEXT_START_MARKER.length, textEnd)
+              .trim();
+            parseBuffer = parseBuffer.slice(textEnd + TEXT_END_MARKER.length);
+            try {
+              const parsed = JSON.parse(textJson);
+              if (parsed.text) {
+                outputChain = outputChain.then(() => onText(parsed.text));
+              }
+            } catch {
+              /* ignore malformed text */
+            }
             resetTimeout();
           }
         }

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -423,6 +423,27 @@ export class StdoutParser extends EventEmitter {
       }
     }
 
+    // Parse text markers (intermediate agent text blocks)
+    let textStart: number;
+    while ((textStart = this.parseBuffer.indexOf(TEXT_START_MARKER)) !== -1) {
+      const textEnd = this.parseBuffer.indexOf(TEXT_END_MARKER, textStart);
+      if (textEnd === -1) break;
+      const textJson = this.parseBuffer
+        .slice(textStart + TEXT_START_MARKER.length, textEnd)
+        .trim();
+      this.parseBuffer = this.parseBuffer.slice(
+        textEnd + TEXT_END_MARKER.length,
+      );
+      try {
+        const parsed = JSON.parse(textJson);
+        if (parsed.text) {
+          this.emit('text', parsed.text as string);
+        }
+      } catch {
+        /* ignore malformed text */
+      }
+    }
+
     // Parse output markers
     let startIdx: number;
     while ((startIdx = this.parseBuffer.indexOf(OUTPUT_START_MARKER)) !== -1) {
@@ -472,6 +493,7 @@ export interface ContainerHandle {
   queryOnce(
     onOutput?: (output: ContainerOutput) => Promise<void>,
     onProgress?: (event: ProgressEvent) => void,
+    onText?: (text: string) => Promise<void>,
     timeoutMs?: number,
   ): Promise<ContainerOutput>;
 }
@@ -479,15 +501,17 @@ export interface ContainerHandle {
 function createQueryOnce(
   handle: ContainerHandle,
 ): ContainerHandle['queryOnce'] {
-  return (onOutput, onProgress, timeoutMs) => {
+  return (onOutput, onProgress, onText, timeoutMs) => {
     return new Promise<ContainerOutput>((resolve) => {
       let resolved = false;
       let timeout: ReturnType<typeof setTimeout> | null = null;
+      let textChain = Promise.resolve();
 
       const cleanup = () => {
         if (timeout) clearTimeout(timeout);
         handle.parser.off('output', onOutputEvent);
         handle.parser.off('progress', onProgressEvent);
+        handle.parser.off('text', onTextEvent);
         handle.parser.off('exit', onExitEvent);
       };
 
@@ -528,6 +552,14 @@ function createQueryOnce(
         if (onProgress) onProgress(event);
       };
 
+      const onTextEvent = (text: string) => {
+        if (resolved) return;
+        resetTimeout();
+        if (onText) {
+          textChain = textChain.then(() => onText(text));
+        }
+      };
+
       const onExitEvent = ({ code }: { code: number | null }) => {
         if (resolved) return;
         resolved = true;
@@ -542,6 +574,7 @@ function createQueryOnce(
 
       handle.parser.on('output', onOutputEvent);
       handle.parser.on('progress', onProgressEvent);
+      handle.parser.on('text', onTextEvent);
       handle.parser.on('exit', onExitEvent);
 
       if (timeoutMs) resetTimeout();
@@ -783,6 +816,7 @@ export async function runContainerAgent(
   onProcess: (proc: ChildProcess, containerName: string) => void,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   onProgress?: (event: ProgressEvent) => void,
+  onText?: (text: string) => Promise<void>,
 ): Promise<ContainerOutput> {
   const handle = await spawnContainer(group, input);
   onProcess(handle.process, handle.containerName);
@@ -794,7 +828,12 @@ export async function runContainerAgent(
       : Math.max(configTimeout, IDLE_TIMEOUT + 30_000);
 
   // First query (already in-flight via stdin)
-  const firstResult = await handle.queryOnce(onOutput, onProgress, timeoutMs);
+  const firstResult = await handle.queryOnce(
+    onOutput,
+    onProgress,
+    onText,
+    timeoutMs,
+  );
 
   // Delegation or error: wait for container to exit, return result
   if (input.isDelegation || firstResult.status === 'error') {
@@ -810,9 +849,14 @@ export async function runContainerAgent(
       if (output.newSessionId) handle.sessionId = output.newSessionId;
       if (onOutput) await onOutput(output);
     };
+    const onSubsequentText = async (text: string) => {
+      if (onText) await onText(text);
+    };
     handle.parser.on('output', onSubsequentOutput);
+    handle.parser.on('text', onSubsequentText);
     handle.exitPromise.then(() => {
       handle.parser.off('output', onSubsequentOutput);
+      handle.parser.off('text', onSubsequentText);
       resolve({
         status: 'success',
         result: null,

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -329,7 +329,11 @@ export function startCredentialProxy(
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
-        // ── /credential/:service — return raw credential value ──────
+        // ── /credential — list available services or fetch a specific one
+        if (req.method === 'GET' && req.url === '/credential') {
+          handleCredentialList(res);
+          return;
+        }
         const credMatch = req.url?.match(/^\/credential\/([a-zA-Z0-9_-]+)$/);
         if (credMatch && req.method === 'GET') {
           handleCredentialLookup(credMatch[1], res);
@@ -455,6 +459,32 @@ function substituteInHeader(
  * Looks up env vars matching the service prefix (e.g., "github" → GITHUB_TOKEN).
  * Used by `cred-exec` inside containers to inject credentials into CLI tools.
  */
+/** List available credential services (by prefix) from .env. */
+function listAvailableServices(
+  env: Record<string, string>,
+): { service: string; envVar: string }[] {
+  const results: { service: string; envVar: string }[] = [];
+  for (const key of Object.keys(env)) {
+    if (CREDENTIAL_PATTERN.test(key) && env[key]) {
+      // Derive service name: GITHUB_TOKEN → github, ATLASSIAN_API_TOKEN → atlassian
+      const match = key.match(/^(.+?)(?:_API)?_(TOKEN|KEY|SECRET|PASSWORD)$/);
+      if (match) {
+        results.push({
+          service: match[1].toLowerCase(),
+          envVar: key,
+        });
+      }
+    }
+  }
+  // Deduplicate by service name (keep first match, which is the one our lookup would find)
+  const seen = new Set<string>();
+  return results.filter((r) => {
+    if (seen.has(r.service)) return false;
+    seen.add(r.service);
+    return true;
+  });
+}
+
 function handleCredentialLookup(
   service: string,
   res: import('http').ServerResponse,
@@ -484,13 +514,34 @@ function handleCredentialLookup(
   }
 
   if (!value || !matchedKey) {
+    const available = listAvailableServices(env);
+    const availableList = available
+      .map((a) => `  - "${a.service}" (${a.envVar})`)
+      .join('\n');
+    const tried = suffixes.map((s) => `${prefix}${s}`).join(', ');
+
     logger.debug(
-      { service, prefix },
+      { service, prefix, availableCount: available.length },
       'Credential lookup: no matching credential found',
     );
-    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
     res.end(
-      JSON.stringify({ error: `No credential found for service: ${service}` }),
+      [
+        `No credential found for service "${service}".`,
+        '',
+        `Looked for env vars: ${tried}`,
+        '',
+        available.length > 0
+          ? `Available services:\n${availableList}`
+          : 'No credentials are configured. Use mcp__nanoclaw__request_credential to register one.',
+        '',
+        'To fix:',
+        `  1. Use one of the available service names listed above`,
+        `  2. Or register a new credential with mcp__nanoclaw__request_credential`,
+        '',
+        'Usage: cred-exec.sh <service> <ENV_VAR> -- <command>',
+        'For HTTP API calls, prefer: api.sh <service> <METHOD> <URL> [CURL_ARGS]',
+      ].join('\n'),
     );
     return;
   }
@@ -501,6 +552,23 @@ function handleCredentialLookup(
   );
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end(value);
+}
+
+/** GET /credential — list all available services (no values exposed). */
+function handleCredentialList(res: import('http').ServerResponse): void {
+  const env = readEnvFile();
+  const available = listAvailableServices(env);
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end(
+    [
+      'Available credential services:',
+      ...available.map((a) => `  - "${a.service}" (${a.envVar})`),
+      '',
+      'Usage: cred-exec.sh <service> <ENV_VAR> -- <command>',
+      'For HTTP API calls: api.sh <service> <METHOD> <URL> [CURL_ARGS]',
+    ].join('\n'),
+  );
 }
 
 // ── /forward handler ────────────────────────────────────────────────

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -329,6 +329,13 @@ export function startCredentialProxy(
       const chunks: Buffer[] = [];
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {
+        // ── /credential/:service — return raw credential value ──────
+        const credMatch = req.url?.match(/^\/credential\/([a-zA-Z0-9_-]+)$/);
+        if (credMatch && req.method === 'GET') {
+          handleCredentialLookup(credMatch[1], res);
+          return;
+        }
+
         // ── /forward — generic credential-injecting forward proxy ───
         if (req.url === '/forward' || req.url?.startsWith('/forward?')) {
           handleForward(req, res, Buffer.concat(chunks));
@@ -439,6 +446,61 @@ function substituteInHeader(
     }
   }
   return substituteCredentials(value, credMap);
+}
+
+// ── /credential/:service handler ────────────────────────────────────
+
+/**
+ * Return the raw credential value for a named service.
+ * Looks up env vars matching the service prefix (e.g., "github" → GITHUB_TOKEN).
+ * Used by `cred-exec` inside containers to inject credentials into CLI tools.
+ */
+function handleCredentialLookup(
+  service: string,
+  res: import('http').ServerResponse,
+): void {
+  const env = readEnvFile();
+  const prefix = service.toUpperCase();
+
+  // Find the best matching credential: try _TOKEN, _KEY, _SECRET, _PASSWORD, _API_TOKEN, _API_KEY
+  const suffixes = [
+    '_TOKEN',
+    '_API_TOKEN',
+    '_API_KEY',
+    '_KEY',
+    '_SECRET',
+    '_PASSWORD',
+  ];
+  let value: string | undefined;
+  let matchedKey: string | undefined;
+
+  for (const suffix of suffixes) {
+    const key = `${prefix}${suffix}`;
+    if (env[key]) {
+      value = env[key];
+      matchedKey = key;
+      break;
+    }
+  }
+
+  if (!value || !matchedKey) {
+    logger.debug(
+      { service, prefix },
+      'Credential lookup: no matching credential found',
+    );
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({ error: `No credential found for service: ${service}` }),
+    );
+    return;
+  }
+
+  logger.debug(
+    { service, key: matchedKey },
+    'Credential lookup: returning value',
+  );
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end(value);
 }
 
 // ── /forward handler ────────────────────────────────────────────────

--- a/src/credential-proxy.ts
+++ b/src/credential-proxy.ts
@@ -311,7 +311,15 @@ function handleForward(
   );
 
   // Build outbound headers with placeholder substitution
-  const parsed = new URL(targetUrl);
+  let parsed: URL;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    logger.warn({ targetUrl }, 'Credential proxy /forward: invalid URL');
+    res.writeHead(400);
+    res.end(`Invalid X-Forward-To URL: ${targetUrl}`);
+    return;
+  }
   const outIsHttps = parsed.protocol === 'https:';
   const makeRequest = outIsHttps ? httpsRequest : httpRequest;
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -413,6 +413,17 @@ export function storeMessageDirect(msg: {
   );
 }
 
+/** Update only the content of an existing message (preserves timestamp and rowid). */
+export function updateMessageContent(
+  id: string,
+  chatJid: string,
+  content: string,
+): void {
+  db.prepare(
+    `UPDATE messages SET content = ? WHERE id = ? AND chat_jid = ?`,
+  ).run(content, id, chatJid);
+}
+
 export function getNewMessages(
   jids: string[],
   lastTimestamp: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1211,6 +1211,7 @@ async function runAgent(
         const result = await warmHandle.queryOnce(
           wrappedOnOutput,
           wrappedOnProgress,
+          onText,
           timeoutMs,
         );
 
@@ -1271,6 +1272,7 @@ async function runAgent(
       const result = await handle.queryOnce(
         wrappedOnOutput,
         wrappedOnProgress,
+        onText,
         timeoutMs,
       );
 
@@ -1310,6 +1312,7 @@ async function runAgent(
         queue.registerProcess(chatJid, proc, containerName, group.folder),
       wrappedOnOutput,
       wrappedOnProgress,
+      onText,
     );
 
     if (output.status === 'error') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,6 +854,22 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             { agent: agent.id, responseJid, threadId: threadId || null },
             `Agent output: ${raw.length} chars → ${threadId ? 'thread' : 'main'}`,
           );
+          if (raw.length > 0 && text.length === 0) {
+            logger.warn(
+              { agent: agent.id, responseJid, rawLen: raw.length },
+              'Agent output entirely stripped by <internal> tag removal — user sees nothing',
+            );
+          } else if (raw.length - text.length > 500) {
+            logger.info(
+              {
+                agent: agent.id,
+                responseJid,
+                rawLen: raw.length,
+                strippedLen: text.length,
+              },
+              `<internal> tags stripped ${raw.length - text.length} chars from agent output`,
+            );
+          }
           if (text) {
             // Re-set agent name before each send — parallel delegations
             // on the same chatJid can clobber the shared activeAgentName
@@ -1620,7 +1636,15 @@ async function main(): Promise<void> {
       }
       // Always strip <internal> tags — agents use these for reasoning
       const stripped = stripInternalTags(rawText);
-      if (!stripped) return;
+      if (!stripped) {
+        if (rawText.trim().length > 0) {
+          logger.warn(
+            { jid, rawLen: rawText.length },
+            'Scheduler output entirely stripped by <internal> tag removal — message dropped',
+          );
+        }
+        return;
+      }
       // Web channel renders blocks client-side — formatOutbound would corrupt
       // :::blocks JSON by transforming markdown inside the fences.
       const text =
@@ -1641,7 +1665,15 @@ async function main(): Promise<void> {
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       // Always strip <internal> tags — agents use these for reasoning
       const stripped = stripInternalTags(rawText);
-      if (!stripped) return Promise.resolve();
+      if (!stripped) {
+        if (rawText.trim().length > 0) {
+          logger.warn(
+            { jid, rawLen: rawText.length },
+            'IPC send_message entirely stripped by <internal> tag removal — message dropped',
+          );
+        }
+        return Promise.resolve();
+      }
       // Web channel renders blocks client-side — formatOutbound would corrupt
       // :::blocks JSON by transforming markdown inside the fences.
       const text =

--- a/src/index.ts
+++ b/src/index.ts
@@ -900,9 +900,12 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       chatJid,
       async (result) => {
         if (result.result) {
-          // If intermediate texts were already streamed to the user, skip
+          // If intermediate texts were actually delivered to the user, skip
           // re-sending the final result to avoid duplicate content.
-          if (result.textsAlreadyStreamed && result.textsAlreadyStreamed > 0) {
+          // Check our local streamedMessageId (not just textsAlreadyStreamed) because
+          // the container may have emitted TEXT markers whose content was stripped
+          // by <internal> tag removal — those don't count as "sent to user".
+          if (streamedMessageId) {
             logger.info(
               {
                 agent: agent.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1104,6 +1104,11 @@ async function runAgent(
         );
         delete sessions[agentId];
         deleteSession(agentId);
+        // Also clear the legacy group-folder key — session resolution falls
+        // back to sessions[group.folder] for default agents, so the stale ID
+        // would be picked up again on retry if only the agent key is cleared.
+        delete sessions[group.folder];
+        deleteSession(group.folder);
       }
       logger.error(
         { agent: agentId, error: output.error },

--- a/src/index.ts
+++ b/src/index.ts
@@ -551,7 +551,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     triggerPattern: getTriggerPattern(group.trigger),
     timezone: TIMEZONE,
     deps: {
-      sendMessage: (text) => channel.sendMessage(chatJid, text),
+      sendMessage: (text) => channel.sendMessage(chatJid, text).then(() => {}),
       setTyping: (typing) =>
         channel.setTyping?.(chatJid, typing) ?? Promise.resolve(),
       runAgent: (prompt, onOutput) => {
@@ -735,6 +735,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
           setActiveAgentName(responseJid, agent.displayName);
           await responseChannel.setTyping?.(responseJid, true, threadId);
+          let mentionStreamedId: string | undefined;
+          let mentionStreamedContent = '';
 
           const status = await runAgent(
             group,
@@ -776,7 +778,22 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
                 .trim();
               if (!text) return;
               setActiveAgentName(responseJid, agent.displayName);
-              await responseChannel.sendMessage(responseJid, text, threadId);
+              if (!mentionStreamedId) {
+                mentionStreamedContent = text;
+                mentionStreamedId = await responseChannel.sendMessage(
+                  responseJid,
+                  text,
+                  threadId,
+                );
+              } else {
+                mentionStreamedContent += '\n\n' + text;
+                await responseChannel.updateMessage?.(
+                  responseJid,
+                  mentionStreamedId,
+                  mentionStreamedContent,
+                  threadId,
+                );
+              }
             },
             agent,
             true, // isDelegation
@@ -874,6 +891,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     let outputSentForCurrentQuery = false;
     let outputSentToUser = false;
     let automationFiredForAgent = false;
+    let streamedMessageId: string | undefined;
+    let streamedContent = '';
 
     const output = await runAgent(
       group,
@@ -977,13 +996,28 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
         broadcastProgress(responseJid, event);
       },
       async (rawText) => {
-        // Intermediate text block — deliver immediately
+        // Intermediate text block — append to a single growing message
         const text = rawText
           .replace(/<internal>[\s\S]*?<\/internal>/g, '')
           .trim();
         if (!text) return;
         setActiveAgentName(responseJid, agent.displayName);
-        await responseChannel.sendMessage(responseJid, text, threadId);
+        if (!streamedMessageId) {
+          streamedContent = text;
+          streamedMessageId = await responseChannel.sendMessage(
+            responseJid,
+            text,
+            threadId,
+          );
+        } else {
+          streamedContent += '\n\n' + text;
+          await responseChannel.updateMessage?.(
+            responseJid,
+            streamedMessageId,
+            streamedContent,
+            threadId,
+          );
+        }
         outputSentToUser = true;
         outputSentForCurrentQuery = true;
         resetIdleTimer();
@@ -1913,7 +1947,7 @@ async function main(): Promise<void> {
           ? stripped
           : formatOutbound(stripped, channel.name as ChannelType);
       if (!text) return Promise.resolve();
-      return channel.sendMessage(jid, text);
+      return channel.sendMessage(jid, text).then(() => {});
     },
     registeredGroups: () => registeredGroups,
     registerGroup,
@@ -2061,6 +2095,8 @@ async function main(): Promise<void> {
 
         setActiveAgentName(chatJid, agent.displayName);
         await channel.setTyping?.(chatJid, true);
+        let delegationStreamedId: string | undefined;
+        let delegationStreamedContent = '';
 
         const status = await runAgent(
           group,
@@ -2105,7 +2141,17 @@ async function main(): Promise<void> {
               .trim();
             if (!text) return;
             setActiveAgentName(chatJid, agent.displayName);
-            await channel.sendMessage(chatJid, text);
+            if (!delegationStreamedId) {
+              delegationStreamedContent = text;
+              delegationStreamedId = await channel.sendMessage(chatJid, text);
+            } else {
+              delegationStreamedContent += '\n\n' + text;
+              await channel.updateMessage?.(
+                chatJid,
+                delegationStreamedId,
+                delegationStreamedContent,
+              );
+            }
           },
           agent,
           true, // isDelegation — use shorter timeout

--- a/src/index.ts
+++ b/src/index.ts
@@ -540,6 +540,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           chatJid,
           onOutput,
           undefined,
+          undefined, // onText — session commands don't stream intermediate text
           defaultAgent,
         );
       },
@@ -719,20 +720,27 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
             chatJid,
             async (result) => {
               if (result.result) {
-                const raw =
-                  typeof result.result === 'string'
-                    ? result.result
-                    : JSON.stringify(result.result);
-                const text = raw
-                  .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-                  .trim();
-                if (text) {
-                  setActiveAgentName(responseJid, agent.displayName);
-                  await responseChannel.sendMessage(
-                    responseJid,
-                    text,
-                    threadId,
-                  );
+                if (
+                  result.textsAlreadyStreamed &&
+                  result.textsAlreadyStreamed > 0
+                ) {
+                  // Text already delivered via intermediate markers
+                } else {
+                  const raw =
+                    typeof result.result === 'string'
+                      ? result.result
+                      : JSON.stringify(result.result);
+                  const text = raw
+                    .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                    .trim();
+                  if (text) {
+                    setActiveAgentName(responseJid, agent.displayName);
+                    await responseChannel.sendMessage(
+                      responseJid,
+                      text,
+                      threadId,
+                    );
+                  }
                 }
               }
               if (result.status === 'success' || result.status === 'error') {
@@ -740,6 +748,14 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
               }
             },
             (event) => broadcastProgress(responseJid, event),
+            async (rawText) => {
+              const text = rawText
+                .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                .trim();
+              if (!text) return;
+              setActiveAgentName(responseJid, agent.displayName);
+              await responseChannel.sendMessage(responseJid, text, threadId);
+            },
             agent,
             true, // isDelegation
           );
@@ -843,40 +859,53 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       chatJid,
       async (result) => {
         if (result.result) {
-          const raw =
-            typeof result.result === 'string'
-              ? result.result
-              : JSON.stringify(result.result);
-          const text = raw
-            .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-            .trim();
-          logger.info(
-            { agent: agent.id, responseJid, threadId: threadId || null },
-            `Agent output: ${raw.length} chars → ${threadId ? 'thread' : 'main'}`,
-          );
-          if (raw.length > 0 && text.length === 0) {
-            logger.warn(
-              { agent: agent.id, responseJid, rawLen: raw.length },
-              'Agent output entirely stripped by <internal> tag removal — user sees nothing',
-            );
-          } else if (raw.length - text.length > 500) {
+          // If intermediate texts were already streamed to the user, skip
+          // re-sending the final result to avoid duplicate content.
+          if (result.textsAlreadyStreamed && result.textsAlreadyStreamed > 0) {
             logger.info(
               {
                 agent: agent.id,
                 responseJid,
-                rawLen: raw.length,
-                strippedLen: text.length,
+                textsStreamed: result.textsAlreadyStreamed,
               },
-              `<internal> tags stripped ${raw.length - text.length} chars from agent output`,
+              'Final result skipped — text already streamed via intermediate markers',
             );
-          }
-          if (text) {
-            // Re-set agent name before each send — parallel delegations
-            // on the same chatJid can clobber the shared activeAgentName
-            setActiveAgentName(responseJid, agent.displayName);
-            await responseChannel.sendMessage(responseJid, text, threadId);
             outputSentToUser = true;
             outputSentForCurrentQuery = true;
+          } else {
+            const raw =
+              typeof result.result === 'string'
+                ? result.result
+                : JSON.stringify(result.result);
+            const text = raw
+              .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+              .trim();
+            logger.info(
+              { agent: agent.id, responseJid, threadId: threadId || null },
+              `Agent output: ${raw.length} chars → ${threadId ? 'thread' : 'main'}`,
+            );
+            if (raw.length > 0 && text.length === 0) {
+              logger.warn(
+                { agent: agent.id, responseJid, rawLen: raw.length },
+                'Agent output entirely stripped by <internal> tag removal — user sees nothing',
+              );
+            } else if (raw.length - text.length > 500) {
+              logger.info(
+                {
+                  agent: agent.id,
+                  responseJid,
+                  rawLen: raw.length,
+                  strippedLen: text.length,
+                },
+                `<internal> tags stripped ${raw.length - text.length} chars from agent output`,
+              );
+            }
+            if (text) {
+              setActiveAgentName(responseJid, agent.displayName);
+              await responseChannel.sendMessage(responseJid, text, threadId);
+              outputSentToUser = true;
+              outputSentForCurrentQuery = true;
+            }
           }
           resetIdleTimer();
         }
@@ -901,18 +930,17 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
           }
 
           queue.notifyIdle(chatJid);
-          if (!outputSentForCurrentQuery && !result.result) {
+          if (
+            !outputSentForCurrentQuery &&
+            !result.result &&
+            !(result.textsAlreadyStreamed && result.textsAlreadyStreamed > 0)
+          ) {
             logger.warn(
               { agent: agent.id },
               'Agent returned null result after retry — silent completion',
             );
           }
           await responseChannel.setTyping?.(responseJid, false, threadId);
-          // Only reset the flag when the success event carried actual output.
-          // The agent-runner emits a second {status:'success', result:null}
-          // as a session-update marker after the query loop — resetting here
-          // unconditionally caused the null-result warning to fire spuriously
-          // on that second event even when the first event delivered text.
           if (result.result) {
             outputSentForCurrentQuery = false;
           }
@@ -925,6 +953,18 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       },
       (event) => {
         broadcastProgress(responseJid, event);
+      },
+      async (rawText) => {
+        // Intermediate text block — deliver immediately
+        const text = rawText
+          .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+          .trim();
+        if (!text) return;
+        setActiveAgentName(responseJid, agent.displayName);
+        await responseChannel.sendMessage(responseJid, text, threadId);
+        outputSentToUser = true;
+        outputSentForCurrentQuery = true;
+        resetIdleTimer();
       },
       agent,
     );
@@ -978,6 +1018,7 @@ async function runAgent(
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
   onProgress?: (event: ProgressEvent) => void,
+  onText?: (text: string) => Promise<void>,
   agent?: Agent,
   isDelegation?: boolean,
 ): Promise<'success' | 'error'> {
@@ -1087,6 +1128,7 @@ async function runAgent(
         queue.registerProcess(chatJid, proc, containerName, group.folder),
       wrappedOnOutput,
       onProgress,
+      onText,
     );
 
     if (output.status === 'error') {
@@ -1841,18 +1883,25 @@ async function main(): Promise<void> {
           chatJid,
           async (result) => {
             if (result.result) {
-              const raw =
-                typeof result.result === 'string'
-                  ? result.result
-                  : JSON.stringify(result.result);
-              const text = raw
-                .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-                .trim();
-              if (text) {
-                // Set agent name right before sending — parallel delegations
-                // share the same chatJid so we must claim the name each time
-                setActiveAgentName(chatJid, agent.displayName);
-                await channel.sendMessage(chatJid, text);
+              if (
+                result.textsAlreadyStreamed &&
+                result.textsAlreadyStreamed > 0
+              ) {
+                // Text already delivered via intermediate markers
+              } else {
+                const raw =
+                  typeof result.result === 'string'
+                    ? result.result
+                    : JSON.stringify(result.result);
+                const text = raw
+                  .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                  .trim();
+                if (text) {
+                  // Set agent name right before sending — parallel delegations
+                  // share the same chatJid so we must claim the name each time
+                  setActiveAgentName(chatJid, agent.displayName);
+                  await channel.sendMessage(chatJid, text);
+                }
               }
             }
             // Delegation containers exit on their own (isDelegation skips
@@ -1865,6 +1914,14 @@ async function main(): Promise<void> {
             }
           },
           (event) => broadcastProgress(chatJid, event),
+          async (rawText) => {
+            const text = rawText
+              .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+              .trim();
+            if (!text) return;
+            setActiveAgentName(chatJid, agent.displayName);
+            await channel.sendMessage(chatJid, text);
+          },
           agent,
           true, // isDelegation — use shorter timeout
         );

--- a/src/router.ts
+++ b/src/router.ts
@@ -35,14 +35,14 @@ export function formatOutbound(rawText: string, channel?: ChannelType): string {
   return channel ? parseTextStyles(text, channel) : text;
 }
 
-export function routeOutbound(
+export async function routeOutbound(
   channels: Channel[],
   jid: string,
   text: string,
 ): Promise<void> {
   const channel = channels.find((c) => c.ownsJid(jid) && c.isConnected());
   if (!channel) throw new Error(`No channel for JID: ${jid}`);
-  return channel.sendMessage(jid, text);
+  await channel.sendMessage(jid, text);
 }
 
 export function findChannel(

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,12 +137,19 @@ export interface TaskRunLog {
 export interface Channel {
   name: string;
   connect(): Promise<void>;
-  sendMessage(jid: string, text: string, threadId?: string): Promise<void>;
+  sendMessage(jid: string, text: string, threadId?: string): Promise<string>;
   isConnected(): boolean;
   ownsJid(jid: string): boolean;
   disconnect(): Promise<void>;
   // Optional: typing indicator. Channels that support it implement it.
   setTyping?(jid: string, isTyping: boolean, threadId?: string): Promise<void>;
+  // Optional: update a previously sent message in-place.
+  updateMessage?(
+    jid: string,
+    messageId: string,
+    text: string,
+    threadId?: string,
+  ): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface AllowedRoot {
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
+  sshAgent?: boolean; // Mount host SSH_AUTH_SOCK into container (default: false)
 }
 
 export interface RegisteredGroup {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -79,6 +79,7 @@ api.onSSE('message', (data) => {
     messages.value = [
       ...messages.value,
       {
+        id: data.message_id,
         role: 'assistant',
         content: data.text,
         timestamp: data.timestamp,
@@ -94,6 +95,16 @@ api.onSSE('message', (data) => {
     // Ding for message in background group
     playNotification(data.jid);
   }
+});
+
+api.onSSE('message_update', (data) => {
+  // Update an existing message in-place (used for streaming intermediate text)
+  if (data.jid === selectedJid.value) {
+    messages.value = messages.value.map((m) =>
+      m.id === data.message_id ? { ...m, content: data.text } : m
+    );
+  }
+  // No notification sound — it's an update, not a new message
 });
 
 api.onSSE('typing', (data) => {

--- a/web/js/components/blocks/CodeBlock.js
+++ b/web/js/components/blocks/CodeBlock.js
@@ -1,7 +1,9 @@
 import { html } from 'htm/preact';
 import { useRef, useEffect, useState } from 'preact/hooks';
 
-export function CodeBlock({ content, language, filename }) {
+export function CodeBlock({ content, code, language, filename }) {
+  // Accept both "content" and "code" — agents may use either field name
+  content = content || code || '';
   const codeRef = useRef(null);
   const [copied, setCopied] = useState(false);
 


### PR DESCRIPTION
## Summary

- **`/credential/:service` proxy endpoint** — returns raw credential value for CLI tools to fetch on demand
- **`GET /credential` listing** — returns all available services with env var names (no secrets). AI-friendly 404 errors show what's available and how to fix
- **`cred-exec.sh` container utility** — generic wrapper that injects credentials for any CLI tool (`cred-exec.sh github GITHUB_TOKEN -- gh pr list`)
- **SSH agent forwarding** — opt-in `containerConfig.sshAgent` mounts host SSH_AUTH_SOCK into containers
- **`credential-proxy` container skill** — comprehensive docs covering api.sh, cred-exec, auth patterns, SSH, troubleshooting
- **Intermediate text accumulation** — TEXT streaming blocks append to a single growing message instead of separate bubbles
- **Message order fix** — `updateMessage` uses UPDATE instead of INSERT OR REPLACE to preserve row position on refresh
- **Silent drop fix** — final results no longer skipped when intermediate TEXT markers were all `<internal>` tags

## Design

The credential proxy already handles HTTP credential injection via `/forward`. This adds a complementary path for CLI tools:

1. `GET /credential/:service` — looks up best matching credential in `.env` (e.g. "github" → GITHUB_TOKEN)
2. `GET /credential` — lists all available services (no values) for discovery
3. `cred-exec.sh` fetches from the endpoint and sets it as an env var for `exec "$@"`
4. 404 responses include available services and fix instructions so agents self-correct

## Test plan

- [x] `api.sh` still works for HTTP calls (no regression)
- [x] `cred-exec.sh github GITHUB_TOKEN -- gh repo view ...` authenticates correctly
- [x] `GET /credential` lists all available services
- [x] `GET /credential/nonexistent` returns helpful 404 with available services
- [x] Agent in General channel used GitHub API unprompted with no explicit credential instructions
- [x] TEXT streaming accumulates into single message (no multiple bubbles)
- [x] Message order preserved on page refresh
- [x] Final results delivered when intermediate texts were all `<internal>` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)