### PR TITLE
Fix six triaged issues (#13-#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ agents-sdk-docs
 
 # Clawdoodles — AI-generated templates (runtime output)
 clawdoodles/generated/
+
+# Playwright MCP runtime output
+.playwright-mcp/

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -668,7 +668,19 @@ export async function spawnContainer(
       .trim()
       .split('\n')
       .filter(Boolean);
+    const now = Date.now();
     for (const name of existing) {
+      // Skip recently-spawned containers to avoid killing in-flight queries.
+      // Container names embed Date.now() as a suffix.
+      const tsMatch = name.match(/-(\d{13,})$/);
+      const spawnedAt = tsMatch ? parseInt(tsMatch[1], 10) : 0;
+      if (spawnedAt && now - spawnedAt < 60_000) {
+        logger.info(
+          { group: group.name, recent: name, ageMs: now - spawnedAt },
+          'Skipping recent container (< 60s old)',
+        );
+        continue;
+      }
       logger.info(
         { group: group.name, stale: name },
         'Stopping stale container before spawn',

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -74,6 +74,7 @@ describe('ensureContainerRuntimeRunning', () => {
     expect(mockExecSync).toHaveBeenCalledTimes(1);
     expect(mockExecSync).toHaveBeenCalledWith(`${CONTAINER_RUNTIME_BIN} info`, {
       stdio: 'pipe',
+      timeout: 10_000,
     });
     expect(logger.debug).toHaveBeenCalledWith(
       'Container runtime already running',

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -77,7 +77,10 @@ export function stopContainer(name: string): void {
  */
 export function ensureContainerRuntimeRunning(): boolean {
   try {
-    execSync(`${CONTAINER_RUNTIME_BIN} info`, { stdio: 'pipe' });
+    execSync(`${CONTAINER_RUNTIME_BIN} info`, {
+      stdio: 'pipe',
+      timeout: 10_000,
+    });
     logger.debug('Container runtime already running');
     return true;
   } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ let lastTimestamp = '';
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 // Agents per group: groupJid → Agent[]
-let groupAgents: Record<string, Agent[]> = {};
+const groupAgents: Record<string, Agent[]> = {};
 let lastAgentTimestamp: Record<string, string> = {};
 let messageLoopRunning = false;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -767,8 +767,9 @@ async function executeAutomationActions(
                 },
                 (event) => broadcastProgress(chatJid, event),
                 async (rawText) => {
-                  // TEXT markers deliver the actual message content AND
-                  // broadcast a progress summary for the typing indicator.
+                  // TEXT markers deliver the actual message content as a chat
+                  // message — no extra progress broadcast (would duplicate into
+                  // the typing indicator's tool history).
                   const text = rawText
                     .replace(/<internal>[\s\S]*?<\/internal>/g, '')
                     .trim();
@@ -779,13 +780,6 @@ async function executeAutomationActions(
                   ) {
                     deliveredToUser = true;
                   }
-                  const summary =
-                    text.length > 120 ? text.slice(0, 117) + '...' : text;
-                  broadcastProgress(chatJid, {
-                    tool: 'text',
-                    summary,
-                    timestamp: new Date().toISOString(),
-                  });
                 },
                 agent,
                 true, // isDelegation
@@ -1238,18 +1232,24 @@ async function processGroupMessages(
               },
               (event) => broadcastProgress(responseJid, event),
               async (rawText) => {
+                // Deliver intermediate text as a chat message; the typing
+                // indicator's tool history is reserved for actual tool calls.
                 const text = rawText
                   .replace(/<internal>[\s\S]*?<\/internal>/g, '')
                   .trim();
                 if (!text) return;
                 setActiveAgentName(responseJid, agent.displayName);
-                const summary =
-                  text.length > 120 ? text.slice(0, 117) + '...' : text;
-                broadcastProgress(responseJid, {
-                  tool: 'text',
-                  summary,
-                  timestamp: new Date().toISOString(),
-                });
+                if (
+                  await deliverAgentMessage(
+                    responseChannel,
+                    responseJid,
+                    text,
+                    lease,
+                    threadId,
+                  )
+                ) {
+                  deliveredToUser = true;
+                }
               },
               agent,
               true, // isDelegation
@@ -2937,13 +2937,6 @@ async function main(): Promise<void> {
               if (await deliverAgentMessage(channel, chatJid, text, lease)) {
                 deliveredToUser = true;
               }
-              const summary =
-                text.length > 120 ? text.slice(0, 117) + '...' : text;
-              broadcastProgress(chatJid, {
-                tool: 'text',
-                summary,
-                timestamp: new Date().toISOString(),
-              });
             },
             agent,
             true, // isDelegation — use shorter timeout

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -183,6 +183,9 @@ api.onSSE('play_sound', (data) => {
 });
 
 api.onSSE('agent_progress', (data) => {
+  // Drop late-arriving progress events for groups that have already cleared
+  // their typing state — prevents the indicator from flashing stale data.
+  if (!typingGroups.value[data.jid]) return;
   const prev = agentProgress.value[data.jid];
   const history = prev?.history || [];
   // Keep last 20 progress events for the transcript

--- a/web/js/components/TypingIndicator.js
+++ b/web/js/components/TypingIndicator.js
@@ -43,8 +43,9 @@ export function TypingIndicator() {
     ? (minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`)
     : '';
 
-  // Show recent tool activity
-  const history = progress?.history || [];
+  // Show recent tool activity (filter out text events — those are message
+  // content delivered via chat, not tool calls)
+  const history = (progress?.history || []).filter((t) => t.tool !== 'text');
   const recentTools = history.slice(-3);
   const label = phase ? (PHASE_LABELS[phase] || phase) : 'thinking';
   const showDots = isTyping || ['working', 'delegating', 'task_running'].includes(phase || '');

--- a/web/js/components/blocks/AlertBlock.js
+++ b/web/js/components/blocks/AlertBlock.js
@@ -3,14 +3,15 @@ import { md } from '../../markdown.js';
 
 const ICONS = { success: '\u2714', warn: '\u26A0', error: '\u2718', info: '\u2139' };
 
-export function AlertBlock({ level, title, body }) {
-  const lvl = level || 'info';
+export function AlertBlock({ level, style, title, body, message }) {
+  const lvl = level || style || 'info';
+  const content = body || message || '';
   return html`
     <div class="alert-block alert-${lvl}">
       <span class="alert-icon">${ICONS[lvl] || ICONS.info}</span>
       <div class="alert-content">
         ${title && html`<div class="alert-title">${title}</div>`}
-        <div class="alert-body" dangerouslySetInnerHTML=${{ __html: md(body) }} />
+        <div class="alert-body" dangerouslySetInnerHTML=${{ __html: md(content) }} />
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary
Six small, independent fixes from the open issue triage. One commit per issue; each commit has a `Closes #N` trailer.

- **#13** — `let groupAgents` → `const` in `src/index.ts` (never reassigned)
- **#14** — Skip stopping recently-spawned containers (<60s old) in `spawnContainer`, ending the retry cascade when slow API calls collide with stale-cleanup
- **#15** — Add 10s timeout to `docker info` health check so an unresponsive runtime can't block process startup
- **#16** — Stop leaking agent text into the typing indicator's tool history (three sub-fixes across `src/index.ts`, `web/js/app.js`, `TypingIndicator.js`). Also fixes a latent bug in the parallel multi-agent fanout path where intermediate text was never delivered as a chat message
- **#17** — `AlertBlock` accepts `style`/`message` aliases for `level`/`body`
- **#18** — `.gitignore` `.playwright-mcp/`

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 416/416 passing (updated `container-runtime.test.ts` for the new timeout option)
- [x] Smoke test: send a delegated message and confirm typing indicator shows tool calls only (no message text)
- [x] Smoke test: trigger a stale-container scenario and confirm no cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)