### PR TITLE
Add maxTurns and disallowedTools safety rails for agents

### DIFF
--- a/container/agent-runner/src/claude-runtime.ts
+++ b/container/agent-runner/src/claude-runtime.ts
@@ -382,6 +382,8 @@ export class ClaudeCodeRuntime implements RuntimeSession {
       process.env.CLAUDE_MODEL ||
       undefined;
 
+    const { maxTurns, disallowedTools } = input.constraints ?? {};
+
     for await (const message of query({
       prompt: stream,
       options: {
@@ -390,6 +392,8 @@ export class ClaudeCodeRuntime implements RuntimeSession {
         additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
         resume: this.options.sessionId,
         resumeSessionAt: this.options.resumeAt,
+        maxTurns,
+        disallowedTools,
         systemPrompt: globalClaudeMd
           ? {
               type: 'preset' as const,

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -19,7 +19,7 @@ import path from 'path';
 import { execFile } from 'child_process';
 import { query, HookCallback, PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { fileURLToPath } from 'url';
-import { AgentRuntimeConfig } from './runtime-interface.js';
+import { AgentRuntimeConfig, RuntimeTurnConstraints } from './runtime-interface.js';
 import { ClaudeCodeRuntime } from './claude-runtime.js';
 
 interface ContainerInput {
@@ -39,6 +39,7 @@ interface ContainerInput {
   mainChatJid?: string;
   script?: string;
   runtime?: AgentRuntimeConfig;
+  constraints?: RuntimeTurnConstraints;
   achievements?: { id: string; name: string; description: string }[];
 }
 
@@ -459,6 +460,7 @@ async function runQuery(
     threadId: undefined,
     agentId: containerInput.agentId || containerInput.agentName || 'default',
     runtime: containerInput.runtime || { provider: 'anthropic' },
+    constraints: containerInput.constraints,
   })) {
     if (event.type === 'progress') {
       writeProgress({

--- a/container/agent-runner/src/runtime-interface.ts
+++ b/container/agent-runner/src/runtime-interface.ts
@@ -46,6 +46,11 @@ export interface RuntimeMessage {
   content: RuntimeInputPart[];
 }
 
+export interface RuntimeTurnConstraints {
+  maxTurns?: number;
+  disallowedTools?: string[];
+}
+
 export interface RuntimeTurnInput {
   systemPrompt?: string;
   messages: RuntimeMessage[];
@@ -53,6 +58,7 @@ export interface RuntimeTurnInput {
   threadId?: string;
   agentId: string;
   runtime: AgentRuntimeConfig;
+  constraints?: RuntimeTurnConstraints;
 }
 
 export interface RuntimeUsageData {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -35,7 +35,7 @@ import { detectAuthMode } from './credential-proxy.js';
 import { validateAdditionalMounts } from './mount-security.js';
 import { readEnvFile } from './env.js';
 import { RegisteredGroup } from './types.js';
-import { AgentRuntimeConfig } from './runtime-types.js';
+import { AgentRuntimeConfig, RuntimeTurnConstraints } from './runtime-types.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
@@ -68,6 +68,7 @@ export interface ContainerInput {
   mainChatJid?: string; // JID of the main group (for escalation messaging)
   script?: string;
   runtime?: AgentRuntimeConfig; // future provider/runtime boundary
+  constraints?: RuntimeTurnConstraints; // per-turn safety rails (maxTurns, disallowedTools)
   achievements?: { id: string; name: string; description: string }[];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,10 @@ import {
   startRemoteControl,
   stopRemoteControl,
 } from './remote-control.js';
-import { resolveEffectiveRuntime } from './runtime-resolution.js';
+import {
+  resolveEffectiveRuntime,
+  resolveTurnConstraints,
+} from './runtime-resolution.js';
 import {
   isSenderAllowed,
   isTriggerAllowed,
@@ -2009,6 +2012,7 @@ async function runAgent(
         agentName: agent?.name || DEFAULT_AGENT_NAME,
         runBatchId,
         runtime: resolveEffectiveRuntime(agent, group.folder),
+        constraints: resolveTurnConstraints(agent, group),
         canDelegate: agent ? !agent.trigger : false,
         isDelegation: isDelegation || false,
         poolManaged: true,
@@ -2083,6 +2087,7 @@ async function runAgent(
       agentName: agent?.name || DEFAULT_AGENT_NAME,
       runBatchId,
       runtime: resolveEffectiveRuntime(agent, group.folder),
+      constraints: resolveTurnConstraints(agent, group),
       canDelegate: agent ? !agent.trigger : false,
       isDelegation: isDelegation || false,
       poolManaged: false,

--- a/src/runtime-resolution.test.ts
+++ b/src/runtime-resolution.test.ts
@@ -3,7 +3,35 @@ import { describe, expect, it } from 'vitest';
 import {
   envRuntimeFallback,
   mergeRuntimeConfigs,
+  resolveTurnConstraints,
 } from './runtime-resolution.js';
+import type { Agent, RegisteredGroup } from './types.js';
+
+function makeGroup(
+  containerConfig?: RegisteredGroup['containerConfig'],
+): RegisteredGroup {
+  return {
+    name: 'Test',
+    folder: 'test',
+    trigger: '@test',
+    added_at: '2026-04-17T00:00:00.000Z',
+    containerConfig,
+  };
+}
+
+function makeAgent(
+  trigger: string | undefined,
+  containerConfig?: Agent['containerConfig'],
+): Agent {
+  return {
+    id: 'test/agent',
+    groupFolder: 'test',
+    name: 'agent',
+    displayName: 'Agent',
+    trigger,
+    containerConfig,
+  };
+}
 
 describe('runtime-resolution', () => {
   it('merges runtime configs with later entries taking precedence', () => {
@@ -37,5 +65,82 @@ describe('runtime-resolution', () => {
       provider: 'anthropic',
       model: 'claude-opus-4-1',
     });
+  });
+});
+
+describe('resolveTurnConstraints', () => {
+  it('returns undefined when no config and no specialist trigger', () => {
+    expect(resolveTurnConstraints(undefined, makeGroup())).toBeUndefined();
+    expect(
+      resolveTurnConstraints(makeAgent(undefined), makeGroup()),
+    ).toBeUndefined();
+  });
+
+  it('auto-blocks delegate_to_agent for specialists', () => {
+    const result = resolveTurnConstraints(makeAgent('@analyst'), makeGroup());
+    expect(result).toEqual({
+      disallowedTools: ['mcp__nanoclaw__delegate_to_agent'],
+    });
+  });
+
+  it('does not auto-block for coordinators (no trigger)', () => {
+    expect(
+      resolveTurnConstraints(makeAgent(undefined), makeGroup()),
+    ).toBeUndefined();
+  });
+
+  it('lets agent maxTurns override group maxTurns', () => {
+    const result = resolveTurnConstraints(
+      makeAgent(undefined, { maxTurns: 5 }),
+      makeGroup({ maxTurns: 20 }),
+    );
+    expect(result).toEqual({ maxTurns: 5 });
+  });
+
+  it('falls back to group maxTurns when agent has none', () => {
+    const result = resolveTurnConstraints(
+      makeAgent(undefined),
+      makeGroup({ maxTurns: 12 }),
+    );
+    expect(result).toEqual({ maxTurns: 12 });
+  });
+
+  it('unions disallowedTools from group and agent', () => {
+    const result = resolveTurnConstraints(
+      makeAgent(undefined, { disallowedTools: ['WebSearch'] }),
+      makeGroup({ disallowedTools: ['Bash'] }),
+    );
+    expect(result?.disallowedTools?.sort()).toEqual(['Bash', 'WebSearch']);
+  });
+
+  it('dedupes overlapping disallowedTools', () => {
+    const result = resolveTurnConstraints(
+      makeAgent(undefined, { disallowedTools: ['WebSearch', 'Bash'] }),
+      makeGroup({ disallowedTools: ['Bash'] }),
+    );
+    expect(result?.disallowedTools?.sort()).toEqual(['Bash', 'WebSearch']);
+  });
+
+  it('combines specialist auto-block with configured disallowedTools', () => {
+    const result = resolveTurnConstraints(
+      makeAgent('@scout', { disallowedTools: ['WebSearch'] }),
+      makeGroup(),
+    );
+    expect(result?.disallowedTools?.sort()).toEqual([
+      'WebSearch',
+      'mcp__nanoclaw__delegate_to_agent',
+    ]);
+  });
+
+  it('merges maxTurns and disallowedTools together', () => {
+    const result = resolveTurnConstraints(
+      makeAgent('@scout', { maxTurns: 10, disallowedTools: ['WebSearch'] }),
+      makeGroup({ maxTurns: 50 }),
+    );
+    expect(result?.maxTurns).toBe(10);
+    expect(result?.disallowedTools?.sort()).toEqual([
+      'WebSearch',
+      'mcp__nanoclaw__delegate_to_agent',
+    ]);
   });
 });

--- a/src/runtime-resolution.ts
+++ b/src/runtime-resolution.ts
@@ -3,8 +3,10 @@ import path from 'path';
 
 import { GROUPS_DIR } from './config.js';
 import { resolveGroupFolderPath } from './group-folder.js';
-import { AgentRuntimeConfig } from './runtime-types.js';
-import { Agent } from './types.js';
+import { AgentRuntimeConfig, RuntimeTurnConstraints } from './runtime-types.js';
+import { Agent, ContainerConfig, RegisteredGroup } from './types.js';
+
+const SPECIALIST_AUTO_BLOCKED_TOOL = 'mcp__nanoclaw__delegate_to_agent';
 
 export type PartialRuntimeConfig = Partial<AgentRuntimeConfig>;
 
@@ -112,4 +114,43 @@ export function resolveEffectiveRuntime(
     envRuntimeFallback(env),
     agent?.runtime,
   );
+}
+
+/**
+ * Resolve per-turn constraints by merging group and agent containerConfig.
+ *
+ * maxTurns: agent value wins if set; otherwise group value; otherwise undefined.
+ * disallowedTools: union of group + agent lists, deduped.
+ * Specialists (agents with a trigger) cannot delegate, so
+ * mcp__nanoclaw__delegate_to_agent is always added for them regardless of
+ * config. This is belt-and-suspenders — the MCP tool isn't registered for
+ * specialists either — but it makes the safety rail explicit at the SDK layer.
+ *
+ * Returns undefined when neither cap nor blocklist applies, so the container
+ * input stays minimal.
+ */
+export function resolveTurnConstraints(
+  agent: Agent | undefined,
+  group: RegisteredGroup,
+): RuntimeTurnConstraints | undefined {
+  const groupConfig: ContainerConfig | undefined = group.containerConfig;
+  const agentConfig: ContainerConfig | undefined = agent?.containerConfig;
+
+  const maxTurns = agentConfig?.maxTurns ?? groupConfig?.maxTurns;
+
+  const disallowed = new Set<string>();
+  for (const tool of groupConfig?.disallowedTools ?? []) disallowed.add(tool);
+  for (const tool of agentConfig?.disallowedTools ?? []) disallowed.add(tool);
+
+  // Specialist = agent with a trigger (non-coordinator). Auto-block delegation.
+  if (agent?.trigger) {
+    disallowed.add(SPECIALIST_AUTO_BLOCKED_TOOL);
+  }
+
+  if (maxTurns === undefined && disallowed.size === 0) return undefined;
+
+  return {
+    ...(maxTurns !== undefined ? { maxTurns } : {}),
+    ...(disallowed.size > 0 ? { disallowedTools: [...disallowed] } : {}),
+  };
 }

--- a/src/runtime-types.ts
+++ b/src/runtime-types.ts
@@ -55,6 +55,14 @@ export interface RuntimeMessage {
   content: RuntimeInputPart[];
 }
 
+export interface RuntimeTurnConstraints {
+  // Hard cap on SDK turns before the runtime stops the agent.
+  maxTurns?: number;
+  // Tools the runtime must refuse to expose for this turn.
+  // Exact names (e.g. "WebSearch") or MCP patterns (e.g. "mcp__nanoclaw__delegate_to_agent").
+  disallowedTools?: string[];
+}
+
 export interface RuntimeTurnInput {
   systemPrompt?: string;
   messages: RuntimeMessage[];
@@ -62,6 +70,7 @@ export interface RuntimeTurnInput {
   threadId?: string;
   agentId: string;
   runtime: AgentRuntimeConfig;
+  constraints?: RuntimeTurnConstraints;
 }
 
 export interface RuntimeUsageData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
   sshAgent?: boolean; // Mount host SSH_AUTH_SOCK into container (default: false)
+  maxTurns?: number; // Hard cap on SDK turns per run
+  disallowedTools?: string[]; // Tools refused for this agent (exact names or MCP patterns)
 }
 
 export interface RegisteredGroup {


### PR DESCRIPTION
## What

Per-turn safety rails for agents: hard cap on SDK turns (`maxTurns`) and a deny-list of tools (`disallowedTools`). Plumbed through the provider-agnostic runtime boundary rather than the Anthropic adapter directly, so future adapters (OpenAI, Ollama, etc.) will receive the same `RuntimeTurnInput.constraints` shape and translate it into their own options.

## Why

Runaway SDK turns and delegation loops had no guardrails. Specialists could call `mcp__nanoclaw__delegate_to_agent` (the MCP tool was already env-gated, but not SDK-blocked as belt-and-suspenders). With SDK 0.2.112 (#39) landed, the knobs are now available.

## How it works

**Runtime boundary (abstract):**
- `RuntimeTurnConstraints { maxTurns?, disallowedTools? }` added to both `src/runtime-types.ts` and `container/agent-runner/src/runtime-interface.ts`
- `RuntimeTurnInput` carries optional `constraints`
- `ClaudeCodeRuntime` reads them and forwards to `query()` — future adapters translate into whatever their SDK exposes

**Host side (concrete):**
- `ContainerConfig` gains `maxTurns?: number` and `disallowedTools?: string[]`
- New `resolveTurnConstraints(agent, group)` in `src/runtime-resolution.ts` merges group + agent configs:
  - `maxTurns`: agent value wins; otherwise group; otherwise undefined
  - `disallowedTools`: union, deduped
  - Specialists (agents with a trigger) always get `mcp__nanoclaw__delegate_to_agent` added — belt-and-suspenders over the existing `NANOCLAW_CAN_DELEGATE` env gate at the MCP layer
- Both `containerInput` call sites in `runAgent` attach the resolved constraints alongside the existing `runtime` field
- `ContainerInput` interface extended (both host and container copy — the two-file sync is noted in `feedback_containerinput_sync.md`)

**Usage in `agent.json`:**
```json
{
  "displayName": "Scout",
  "trigger": "@scout",
  "containerConfig": {
    "maxTurns": 10,
    "disallowedTools": ["WebSearch"]
  }
}
```

## How it was tested

- 9 new unit tests in `src/runtime-resolution.test.ts` covering: undefined-return, specialist auto-block, coordinator passthrough, agent-over-group precedence, group fallback, union behavior, dedupe, specialist + configured disallowedTools, and maxTurns + disallowedTools merge.
- `npm run build` clean (host).
- `cd container/agent-runner && npx tsc --noEmit` clean.
- Full `vitest run` — 433/433 pass (up from 424).
- `./container/build.sh` — rebuilt `nanoclaw-agent:latest`, warm pool source caches cleared.
- Compat smoke test: with the existing running service (old host compiled code) + new container image, a ping to `web:general` still responds correctly — confirms `constraints` is optional and backward-compatible.

**Not validated:** full end-to-end with a restarted host service sending constraints over the wire — skipped to avoid interrupting the active running service for marginal signal. The resolver logic is unit-tested; the SDK pass-through is a single-field forward.

Closes #38