### PR TITLE
Fix block naming to reduce LLM hallucination

### DIFF
--- a/container/skills/rich-output/SKILL.md
+++ b/container/skills/rich-output/SKILL.md
@@ -58,19 +58,26 @@ Syntax-highlighted code with a copy button and optional filename badge.
 | `filename` | no | Filename shown as a badge in the header |
 
 ### card
-Titled panel for structured information — status reports, summaries, feature descriptions.
+Titled panel for structured information — status reports, summaries, feature descriptions. Supports both free-form markdown (`body`) and structured key-value data (`rows`).
 
 ```json
 { "type": "card", "title": "Deployment Status", "icon": "🚀", "body": "All 3 services deployed successfully.\n\n- **api**: v2.4.1\n- **web**: v1.8.0\n- **worker**: v3.1.2", "footer": "Deployed 2 minutes ago" }
 ```
 
-**When to use:** Presenting a self-contained summary, status update, or info block that benefits from visual framing. The body supports markdown.
+With structured rows and a status indicator:
+```json
+{ "type": "card", "title": "Triage Run", "status": "success", "rows": [{ "label": "New Bugs", "value": "0" }, { "label": "Open PRs", "value": "1" }] }
+```
+
+**When to use:** Presenting a self-contained summary, status update, or info block that benefits from visual framing. Use `body` for markdown prose, `rows` for key-value data, or both.
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `title` | yes | Card header text |
 | `icon` | no | Emoji or short string shown before the title |
-| `body` | yes | Card content (supports markdown) |
+| `body` | one of `body` or `rows` | Card content (supports markdown). `content` is accepted as an alias. |
+| `rows` | one of `body` or `rows` | Array of `{ label, value }` objects rendered as a key-value list |
+| `status` | no | Colored dot on the header: `success` (green), `warn` (yellow), `error` (red), `info` (blue) |
 | `footer` | no | Muted text at the bottom |
 
 ### table
@@ -87,18 +94,18 @@ Structured data grid. Use when presenting tabular data — cleaner than markdown
 | `columns` | yes | Array of column header strings |
 | `rows` | yes | Array of row arrays (each row is an array of cell values) |
 
-### stat
+### stats
 Key-value stat badges — game HUD style. Perfect for metrics, counters, quick status readouts.
 
 ```json
-{ "type": "stat", "items": [{ "icon": "💬", "label": "Messages", "value": 142 }, { "icon": "✅", "label": "Tasks", "value": 8 }, { "icon": "🔥", "label": "Streak", "value": "5 days" }] }
+{ "type": "stats", "stats": [{ "icon": "💬", "label": "Messages", "value": 142 }, { "icon": "✅", "label": "Tasks", "value": 8 }, { "icon": "🔥", "label": "Streak", "value": "5 days" }] }
 ```
 
-**When to use:** Displaying metrics, counts, quick summaries of numeric data. Each item renders as a compact badge.
+**When to use:** Displaying metrics, counts, quick summaries of numeric data. Each stat renders as a compact badge.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `items` | yes | Array of `{ icon?, label, value }` objects |
+| `stats` | yes | Array of `{ icon?, label, value }` objects |
 
 ### progress
 Progress bar — for task completion, XP, build progress, deployment stages.
@@ -219,7 +226,7 @@ I've analyzed your deployment. Here's the summary:
 [
   { "type": "alert", "level": "success", "body": "Deployment completed successfully." },
   { "type": "table", "columns": ["Service", "Version", "Status"], "rows": [["api", "2.4.1", "✅"], ["web", "1.8.0", "✅"]] },
-  { "type": "stat", "items": [{ "icon": "⏱️", "label": "Duration", "value": "3m 42s" }, { "icon": "📦", "label": "Images", "value": 2 }] }
+  { "type": "stats", "stats": [{ "icon": "⏱️", "label": "Duration", "value": "3m 42s" }, { "icon": "📦", "label": "Images", "value": 2 }] }
 ]
 :::
 
@@ -246,7 +253,7 @@ The content inside `:::blocks` **MUST** be a JSON array (`[...]`), even for a si
 :::blocks
 [
   { "type": "alert", "level": "success", "body": "Deployed." },
-  { "type": "stat", "items": [{ "label": "Duration", "value": "2m" }] }
+  { "type": "stats", "stats": [{ "label": "Duration", "value": "2m" }] }
 ]
 :::
 
@@ -258,7 +265,7 @@ The content inside `:::blocks` **MUST** be a JSON array (`[...]`), even for a si
 ❌ WRONG — multiple objects without array wrapping:
 :::blocks
 { "type": "alert", "level": "success", "body": "Deployed." }
-{ "type": "stat", "items": [{ "label": "Duration", "value": "2m" }] }
+{ "type": "stats", "stats": [{ "label": "Duration", "value": "2m" }] }
 :::
 ```
 
@@ -268,6 +275,11 @@ The content inside `:::blocks` **MUST** be a JSON array (`[...]`), even for a si
 2. **Broken markdown links inside blocks** — Use `[Title](url)` not `*[Title (url)*`. Block body fields support standard markdown.
 3. **Mixing blocks and prose inside the same fence** — Prose goes OUTSIDE the `:::blocks` fence. Inside is JSON only.
 4. **Forgetting the closing `:::`** — Every `:::blocks` must have a matching `:::` on its own line.
+
+## Field Naming
+
+- **`body` and `content` are interchangeable** on all block types. Use whichever feels natural.
+- **Array fields are named after what they contain:** `stats`, `buttons`, `fields`, `rows`, `columns`.
 
 ## Guidelines
 

--- a/web/css/blocks.css
+++ b/web/css/blocks.css
@@ -137,6 +137,39 @@
   line-height: 1.5;
 }
 
+.card-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.card-rows {
+  padding: 4px 14px 8px;
+  font-size: 13px;
+}
+
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.card-row:last-child { border-bottom: none; }
+
+.card-row-label {
+  color: #8b8fa3;
+  flex-shrink: 0;
+}
+
+.card-row-value {
+  text-align: right;
+  font-weight: 500;
+}
+
 .card-footer {
   padding: 6px 14px;
   font-size: 11px;

--- a/web/js/components/blocks/BlockRenderer.js
+++ b/web/js/components/blocks/BlockRenderer.js
@@ -18,6 +18,7 @@ const RENDERERS = {
   alert: AlertBlock,
   card: CardBlock,
   table: TableBlock,
+  stats: StatBlock,
   stat: StatBlock,
   progress: ProgressBlock,
   action: ActionBlock,

--- a/web/js/components/blocks/CardBlock.js
+++ b/web/js/components/blocks/CardBlock.js
@@ -1,14 +1,29 @@
 import { html } from 'htm/preact';
 import { md } from '../../markdown.js';
 
-export function CardBlock({ title, icon, body, content, footer }) {
+const STATUS_COLORS = { success: '#4ade80', warn: '#facc15', error: '#f87171', info: '#60a5fa' };
+
+export function CardBlock({ title, icon, body, content, footer, rows, status }) {
+  const text = body || content || '';
+  const hasRows = Array.isArray(rows) && rows.length > 0;
   return html`
     <div class="card-block pixel-border">
       <div class="card-header">
         ${icon && html`<span class="card-icon">${icon}</span>`}
         <span class="card-title">${title || 'Card'}</span>
+        ${status && STATUS_COLORS[status] && html`<span class="card-status" style="background: ${STATUS_COLORS[status]}" />`}
       </div>
-      <div class="card-body prose" dangerouslySetInnerHTML=${{ __html: md(body || content || '') }} />
+      ${text && html`<div class="card-body prose" dangerouslySetInnerHTML=${{ __html: md(text) }} />`}
+      ${hasRows && html`
+        <div class="card-rows">
+          ${rows.map(r => html`
+            <div class="card-row">
+              <span class="card-row-label">${r.label}</span>
+              <span class="card-row-value">${r.value}</span>
+            </div>
+          `)}
+        </div>
+      `}
       ${footer && html`<div class="card-footer">${footer}</div>`}
     </div>
   `;

--- a/web/js/components/blocks/CodeBlock.js
+++ b/web/js/components/blocks/CodeBlock.js
@@ -1,9 +1,8 @@
 import { html } from 'htm/preact';
 import { useRef, useEffect, useState } from 'preact/hooks';
 
-export function CodeBlock({ content, code, language, filename }) {
-  // Accept both "content" and "code" — agents may use either field name
-  content = content || code || '';
+export function CodeBlock({ content, code, body, language, filename }) {
+  content = content || code || body || '';
   const codeRef = useRef(null);
   const [copied, setCopied] = useState(false);
 

--- a/web/js/components/blocks/DiffBlock.js
+++ b/web/js/components/blocks/DiffBlock.js
@@ -4,8 +4,8 @@ function esc(s) {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-export function DiffBlock({ content, filename }) {
-  const lines = (content || '').split('\n');
+export function DiffBlock({ content, body, filename }) {
+  const lines = (content || body || '').split('\n');
 
   return html`
     <div class="diff-block">

--- a/web/js/components/blocks/StatBlock.js
+++ b/web/js/components/blocks/StatBlock.js
@@ -1,10 +1,11 @@
 import { html } from 'htm/preact';
 
-export function StatBlock({ items }) {
-  if (!items || !items.length) return null;
+export function StatBlock({ stats, items }) {
+  const data = stats || items;
+  if (!data || !data.length) return null;
   return html`
     <div class="stat-block">
-      ${items.map(item => html`
+      ${data.map(item => html`
         <div class="stat-item pixel-border">
           ${item.icon && html`<span class="stat-icon">${item.icon}</span>`}
           <div class="stat-data">

--- a/web/js/components/blocks/TextBlock.js
+++ b/web/js/components/blocks/TextBlock.js
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact';
 import { md } from '../../markdown.js';
 
-export function TextBlock({ content }) {
-  return html`<div class="prose" dangerouslySetInnerHTML=${{ __html: md(content) }} />`;
+export function TextBlock({ content, body }) {
+  return html`<div class="prose" dangerouslySetInnerHTML=${{ __html: md(content || body || '') }} />`;
 }


### PR DESCRIPTION
## Summary

- Rename `stat` → `stats` (type) and `items` → `stats` (field) so the naming matches LLM intuition — plural type for a collection block, descriptive field name matching what it contains
- Add `rows` (key-value list) and `status` (colored dot) support to cards — agents kept inventing this pattern, now it works
- Universal `body`/`content` aliasing on all block types — no more guessing which field name a block expects
- All old syntax preserved via backward-compat aliases

## Test plan

- [x] Verified in browser: new syntax (`stats`/`stats`, card `rows`/`status`) renders correctly
- [x] Verified backward compat: old syntax (`stat`/`items`, card `body`) still renders
- [x] Confirmed previously broken bug squad messages now render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)