### PR TITLE
Add PATCH /api/tasks/:id endpoint for updating task metadata

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1576,6 +1576,51 @@ export class WebChannel implements Channel {
       return this.json(res, 200, { ok: true });
     }
 
+    // PATCH /api/tasks/:id — update task metadata
+    const taskPatchMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)$/);
+    if (method === 'PATCH' && taskPatchMatch) {
+      const taskId = decodeURIComponent(taskPatchMatch[1]);
+      const task = getTaskById(taskId);
+      if (!task) return this.json(res, 404, { error: 'Task not found' });
+
+      const body = await this.readBody(req);
+      const updates: Parameters<typeof updateTask>[1] = {};
+
+      if (body.title !== undefined) updates.title = body.title;
+      if (body.prompt !== undefined) updates.prompt = body.prompt;
+      if (body.script !== undefined) updates.script = body.script || null;
+      if (body.schedule_type !== undefined) {
+        if (!['cron', 'interval', 'once'].includes(body.schedule_type)) {
+          return this.json(res, 400, {
+            error: 'schedule_type must be cron, interval, or once',
+          });
+        }
+        updates.schedule_type =
+          body.schedule_type as ScheduledTask['schedule_type'];
+      }
+      if (body.schedule_value !== undefined) {
+        updates.schedule_value = body.schedule_value;
+      }
+
+      if (Object.keys(updates).length === 0) {
+        return this.json(res, 400, { error: 'no updatable fields provided' });
+      }
+
+      if (updates.schedule_type || updates.schedule_value) {
+        const merged = { ...task, ...updates } as ScheduledTask;
+        try {
+          updates.next_run = computeNextRun(merged);
+        } catch {
+          return this.json(res, 400, {
+            error: 'invalid schedule_value for schedule_type',
+          });
+        }
+      }
+
+      updateTask(taskId, updates);
+      return this.json(res, 200, { task: getTaskById(taskId) });
+    }
+
     // DELETE /api/tasks/:id — cancel/delete a task
     const taskDeleteMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)$/);
     if (method === 'DELETE' && taskDeleteMatch) {

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -460,6 +460,35 @@ describe('task CRUD', () => {
     expect(getTaskById('task-2')!.status).toBe('paused');
   });
 
+  it('updates task title, prompt, and schedule', () => {
+    createTask({
+      id: 'task-patch',
+      group_folder: 'main',
+      chat_jid: 'group@g.us',
+      title: 'Old title',
+      prompt: 'old prompt',
+      schedule_type: 'once',
+      schedule_value: '2024-06-01T00:00:00.000Z',
+      context_mode: 'isolated',
+      next_run: '2024-06-01T00:00:00.000Z',
+      status: 'active',
+      created_at: '2024-01-01T00:00:00.000Z',
+    });
+
+    updateTask('task-patch', {
+      title: 'New title',
+      prompt: 'new prompt',
+      schedule_type: 'cron',
+      schedule_value: '0 9 * * 1-5',
+    });
+
+    const task = getTaskById('task-patch')!;
+    expect(task.title).toBe('New title');
+    expect(task.prompt).toBe('new prompt');
+    expect(task.schedule_type).toBe('cron');
+    expect(task.schedule_value).toBe('0 9 * * 1-5');
+  });
+
   it('deletes a task and its run logs', () => {
     createTask({
       id: 'task-3',

--- a/src/db.ts
+++ b/src/db.ts
@@ -714,6 +714,7 @@ export function updateTask(
   updates: Partial<
     Pick<
       ScheduledTask,
+      | 'title'
       | 'prompt'
       | 'script'
       | 'schedule_type'
@@ -726,6 +727,10 @@ export function updateTask(
   const fields: string[] = [];
   const values: unknown[] = [];
 
+  if (updates.title !== undefined) {
+    fields.push('title = ?');
+    values.push(updates.title || null);
+  }
   if (updates.prompt !== undefined) {
     fields.push('prompt = ?');
     values.push(updates.prompt);


### PR DESCRIPTION
## Summary
Adds a `PATCH /api/tasks/:id` endpoint so scheduled-task metadata can be updated in place, instead of requiring delete + recreate (which loses `last_run`, `last_result`, and the task id).

Closes #32

## What
- `updateTask()` in `src/db.ts` now accepts `title` alongside the existing fields.
- New `PATCH /api/tasks/:id` route in `src/channels/web.ts` accepting a partial body with any of: `title`, `prompt`, `script`, `schedule_type`, `schedule_value`.
- Validates `schedule_type` is one of `cron`/`interval`/`once`.
- Recomputes `next_run` via `computeNextRun()` when schedule fields change; returns 400 on invalid cron.
- Returns 404 for unknown task, 400 for empty/invalid body, 200 with the refreshed task on success.

## How it was tested
- New unit test in `src/db.test.ts` covering title/prompt/schedule updates.
- Live-tested against the running service with curl: valid title+prompt (200), schedule change with recomputed `next_run` (200), invalid `schedule_type` (400), invalid cron (400), empty body (400), unknown id (404).
- Full test suite: 434/434 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)