### PR TITLE
Evict warm pool containers when CLAUDE.md changes on host

### DIFF
--- a/src/claude-md-fingerprint.test.ts
+++ b/src/claude-md-fingerprint.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+let tmpRoot: string;
+
+vi.mock('./config.js', async () => {
+  // Redirect GROUPS_DIR and DATA_DIR into a tmp directory per-process.
+  // Populated from the `tmpRoot` variable above once beforeEach runs.
+  return {
+    get GROUPS_DIR() {
+      return path.join(tmpRoot, 'groups');
+    },
+    get DATA_DIR() {
+      return path.join(tmpRoot, 'data');
+    },
+    CONTAINER_IMAGE: 'nanoclaw-agent:latest',
+    CONTAINER_MAX_OUTPUT_SIZE: 10485760,
+    CONTAINER_TIMEOUT: 1800000,
+    CREDENTIAL_PROXY_PORT: 3457,
+    IDLE_TIMEOUT: 1800000,
+    OLLAMA_ADMIN_TOOLS: false,
+    TIMEZONE: 'America/Los_Angeles',
+  };
+});
+
+vi.mock('./container-runtime.js', () => ({
+  CONTAINER_RUNTIME_BIN: 'docker',
+  CONTAINER_HOST_GATEWAY: 'host.docker.internal',
+  hostGatewayArgs: () => [],
+  readonlyMountArgs: () => [],
+  stopContainer: vi.fn(),
+}));
+
+vi.mock('./mount-security.js', () => ({
+  validateAdditionalMounts: () => [],
+}));
+
+vi.mock('./credential-proxy.js', () => ({
+  detectAuthMode: () => ({ mode: 'api-key' }),
+}));
+
+import { computeClaudeMdFingerprint } from './container-runner.js';
+
+describe('computeClaudeMdFingerprint', () => {
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-test-'));
+    fs.mkdirSync(path.join(tmpRoot, 'groups', 'web_demo'), { recursive: true });
+    fs.mkdirSync(path.join(tmpRoot, 'groups', 'global'), { recursive: true });
+    fs.mkdirSync(path.join(tmpRoot, 'groups', 'global-web'), {
+      recursive: true,
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns same hash for identical inputs', () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, 'groups', 'web_demo', 'CLAUDE.md'),
+      'hello',
+    );
+    const a = computeClaudeMdFingerprint('web_demo', false, 'web:demo');
+    const b = computeClaudeMdFingerprint('web_demo', false, 'web:demo');
+    expect(a).toBe(b);
+  });
+
+  it('changes when group CLAUDE.md content changes', () => {
+    const p = path.join(tmpRoot, 'groups', 'web_demo', 'CLAUDE.md');
+    fs.writeFileSync(p, 'original');
+    const before = computeClaudeMdFingerprint('web_demo', false, 'web:demo');
+
+    fs.writeFileSync(p, 'edited');
+    const after = computeClaudeMdFingerprint('web_demo', false, 'web:demo');
+
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when agent CLAUDE.md content changes', () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, 'groups', 'web_demo', 'CLAUDE.md'),
+      'group',
+    );
+    const agentDir = path.join(
+      tmpRoot,
+      'groups',
+      'web_demo',
+      'agents',
+      'analyst',
+    );
+    fs.mkdirSync(agentDir, { recursive: true });
+    const agentMd = path.join(agentDir, 'CLAUDE.md');
+
+    fs.writeFileSync(agentMd, 'v1');
+    const before = computeClaudeMdFingerprint(
+      'web_demo',
+      false,
+      'web:demo',
+      'analyst',
+    );
+
+    fs.writeFileSync(agentMd, 'v2');
+    const after = computeClaudeMdFingerprint(
+      'web_demo',
+      false,
+      'web:demo',
+      'analyst',
+    );
+
+    expect(after).not.toBe(before);
+  });
+
+  it('detects global CLAUDE.md edits for non-main groups', () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, 'groups', 'web_demo', 'CLAUDE.md'),
+      'group',
+    );
+    const globalMd = path.join(tmpRoot, 'groups', 'global', 'CLAUDE.md');
+
+    fs.writeFileSync(globalMd, 'old');
+    const before = computeClaudeMdFingerprint('web_demo', false, 'web:demo');
+
+    fs.writeFileSync(globalMd, 'new');
+    const after = computeClaudeMdFingerprint('web_demo', false, 'web:demo');
+
+    expect(after).not.toBe(before);
+  });
+
+  it('ignores global CLAUDE.md changes for main groups', () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, 'groups', 'web_demo', 'CLAUDE.md'),
+      'group',
+    );
+    const globalMd = path.join(tmpRoot, 'groups', 'global', 'CLAUDE.md');
+
+    fs.writeFileSync(globalMd, 'old');
+    const before = computeClaudeMdFingerprint('web_demo', true, 'web:demo');
+
+    fs.writeFileSync(globalMd, 'new');
+    const after = computeClaudeMdFingerprint('web_demo', true, 'web:demo');
+
+    expect(after).toBe(before);
+  });
+
+  it('handles missing CLAUDE.md files without throwing', () => {
+    // No files created — all paths resolve to missing
+    const hash = computeClaudeMdFingerprint('web_demo', false, 'web:demo');
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/src/container-pool.test.ts
+++ b/src/container-pool.test.ts
@@ -126,6 +126,49 @@ describe('ContainerPool', () => {
     expect(pool.idleCount).toBe(0);
   });
 
+  it('acquire evicts stale container when CLAUDE.md fingerprint changed', () => {
+    const handle = createMockHandle({ claudeMdFingerprint: 'hash-old' });
+    activeHandles.push(handle);
+    pool.release('web_test/default', handle, 'web:test', 'default');
+    expect(pool.idleCount).toBe(1);
+
+    // Simulate host-side CLAUDE.md edit → fingerprint changes
+    expect(pool.acquire('web_test/default', 'hash-new')).toBeNull();
+    expect(pool.idleCount).toBe(0);
+    // Stale container was signaled to close
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('_close'),
+      '',
+    );
+  });
+
+  it('acquire returns handle when fingerprint matches', () => {
+    const handle = createMockHandle({ claudeMdFingerprint: 'hash-a' });
+    activeHandles.push(handle);
+    pool.release('web_test/default', handle, 'web:test', 'default');
+
+    expect(pool.acquire('web_test/default', 'hash-a')).toBe(handle);
+  });
+
+  it('acquire without expectedFingerprint skips the check (back-compat)', () => {
+    const handle = createMockHandle({ claudeMdFingerprint: 'hash-a' });
+    activeHandles.push(handle);
+    pool.release('web_test/default', handle, 'web:test', 'default');
+
+    // Caller passes no expectation → always returns the handle
+    expect(pool.acquire('web_test/default')).toBe(handle);
+  });
+
+  it('acquire without stored fingerprint skips the check', () => {
+    // Handles spawned before the fingerprint feature don't have one.
+    // Rather than mass-evict, the pool should keep serving them.
+    const handle = createMockHandle(); // no claudeMdFingerprint
+    activeHandles.push(handle);
+    pool.release('web_test/default', handle, 'web:test', 'default');
+
+    expect(pool.acquire('web_test/default', 'hash-new')).toBe(handle);
+  });
+
   it('release with pool disabled writes _close immediately', () => {
     const disabledPool = new ContainerPool(5000, false);
     const handle = createMockHandle();

--- a/src/container-pool.ts
+++ b/src/container-pool.ts
@@ -64,8 +64,16 @@ export class ContainerPool {
   /**
    * Try to acquire a warm container for the given agent.
    * Returns handle if idle, null otherwise. Atomically removes from pool.
+   *
+   * If expectedFingerprint is provided and differs from the container's
+   * stored fingerprint, the container is evicted (CLAUDE.md has changed
+   * on the host since it was spawned) and null is returned so the caller
+   * spawns a fresh one with the updated instructions.
    */
-  acquire(agentId: string): ContainerHandle | null {
+  acquire(
+    agentId: string,
+    expectedFingerprint?: string,
+  ): ContainerHandle | null {
     if (!this.enabled) return null;
     const entry = this.entries.get(agentId);
     if (!entry || entry.state !== 'idle' || entry.handle.exited) {
@@ -73,6 +81,22 @@ export class ContainerPool {
       if (entry?.handle.exited) {
         this.removeEntry(agentId);
       }
+      return null;
+    }
+
+    if (
+      expectedFingerprint !== undefined &&
+      entry.handle.claudeMdFingerprint !== undefined &&
+      entry.handle.claudeMdFingerprint !== expectedFingerprint
+    ) {
+      logger.info(
+        {
+          agentId,
+          containerName: entry.handle.containerName,
+        },
+        'Pool: CLAUDE.md changed on host, evicting stale warm container',
+      );
+      this.reclaimSync(agentId);
       return null;
     }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -3,6 +3,7 @@
  * Spawns agent execution in containers and handles IPC
  */
 import { ChildProcess, execSync, spawn } from 'child_process';
+import { createHash } from 'crypto';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
@@ -97,6 +98,46 @@ interface VolumeMount {
   hostPath: string;
   containerPath: string;
   readonly: boolean;
+}
+
+/**
+ * Hash every CLAUDE.md file that will be loaded into this agent's Claude Code
+ * session. Lets the warm pool detect host-side edits and evict stale
+ * containers on the next acquire. Mirrors the path set used by
+ * buildVolumeMounts so any file that's actually mounted gets fingerprinted.
+ */
+export function computeClaudeMdFingerprint(
+  groupFolder: string,
+  isMain: boolean,
+  chatJid: string,
+  agentName?: string,
+): string {
+  const groupDir = resolveGroupFolderPath(groupFolder);
+  const paths: string[] = [path.join(groupDir, 'CLAUDE.md')];
+
+  if (agentName) {
+    paths.push(path.join(groupDir, 'agents', agentName, 'CLAUDE.md'));
+  }
+
+  if (!isMain) {
+    paths.push(path.join(GROUPS_DIR, 'global', 'CLAUDE.md'));
+    if (chatJid.startsWith('web:')) {
+      paths.push(path.join(GROUPS_DIR, 'global-web', 'CLAUDE.md'));
+    }
+  }
+
+  const hash = createHash('sha256');
+  for (const p of paths) {
+    hash.update(p);
+    hash.update('\0');
+    try {
+      hash.update(fs.readFileSync(p));
+    } catch {
+      hash.update('MISSING');
+    }
+    hash.update('\0');
+  }
+  return hash.digest('hex');
 }
 
 function buildVolumeMounts(
@@ -531,6 +572,7 @@ export interface ContainerHandle {
   exited: boolean;
   readonly exitPromise: Promise<{ code: number | null }>;
   queryCount: number;
+  claudeMdFingerprint?: string;
 
   /**
    * Run one query cycle: wait for the next output marker that represents
@@ -871,6 +913,12 @@ export async function spawnContainer(
     exited: false,
     exitPromise,
     queryCount: 0,
+    claudeMdFingerprint: computeClaudeMdFingerprint(
+      group.folder,
+      input.isMain,
+      input.chatJid,
+      input.agentName,
+    ),
     queryOnce: null as unknown as ContainerHandle['queryOnce'],
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import {
   ContainerOutput,
   ProgressEvent,
   UsageData,
+  computeClaudeMdFingerprint,
   runContainerAgent,
   spawnContainer,
   writeGroupsSnapshot,
@@ -1910,7 +1911,13 @@ async function runAgent(
       // container's IPC dir, and they get consumed with no listener.
       queue.setNoPipe(chatJid, true);
 
-      const warmHandle = pool.acquire(agentId);
+      const expectedFingerprint = computeClaudeMdFingerprint(
+        group.folder,
+        isMain,
+        chatJid,
+        agent?.name,
+      );
+      const warmHandle = pool.acquire(agentId, expectedFingerprint);
 
       if (warmHandle) {
         // ── Warm reuse: query existing container ───────────────────


### PR DESCRIPTION
## Summary
Warm pool containers loaded CLAUDE.md into their Claude Code session at spawn time. Host-side edits to group / agent / global CLAUDE.md files took effect on disk via the bind mount, but not in the running session — so warm containers kept serving stale instructions until the idle timeout expired (default 30 min). The CLAUDE.md even documents the workaround (manually `docker stop` the warm container).

Closes #47

## How it works
1. `computeClaudeMdFingerprint(groupFolder, isMain, chatJid, agentName)` in `src/container-runner.ts` hashes every CLAUDE.md file that actually gets mounted for that agent (group, agent-specific, global, global-web — mirrors the path set used by `buildVolumeMounts`).
2. `spawnContainer` computes the fingerprint at spawn and stores it on the `ContainerHandle` (`claudeMdFingerprint`).
3. `ContainerPool.acquire(agentId, expectedFingerprint?)` now accepts an expected fingerprint. Before returning the warm handle, it compares against the one captured at spawn. On mismatch, it writes `_close`, removes the entry, and returns `null` — the caller then spawns a fresh container with the up-to-date instructions.
4. The one caller in `src/index.ts` computes the current fingerprint before calling `acquire`.

Back-compat: if either side's fingerprint is missing (e.g. legacy handle, test fixture), the check is skipped.

## How it was tested
- 6 unit tests for `computeClaudeMdFingerprint` covering same-inputs stability, group/agent/global edits, main vs non-main scoping, missing files.
- 4 new `ContainerPool` tests covering eviction on mismatch, normal return on match, and the two skip-the-check paths.
- Full test suite: 444/444 passing.
- Service restarted cleanly after the change (health endpoint 200).

Full end-to-end eviction (Docker spawn → host edit → next message gets fresh container) not exercised locally because Docker wasn't running on my box; the unit tests cover both halves of the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)