### PR TITLE
Surface block-parser recovery as console warnings

### DIFF
--- a/web/js/block-parser.js
+++ b/web/js/block-parser.js
@@ -64,19 +64,42 @@ export function parseBlocks(content) {
 function parseBlocksFence(body, blocks) {
   try {
     const parsed = JSON.parse(body);
-    const arr = Array.isArray(parsed) ? parsed : [parsed];
-    for (const block of arr) {
-      if (block && block.type) blocks.push(block);
+    if (Array.isArray(parsed)) {
+      for (const block of parsed) {
+        if (block && block.type) blocks.push(block);
+      }
+    } else {
+      warnRecovery(
+        'bare-object-in-blocks-fence',
+        'expected an array of blocks but got a single object — auto-wrapped. Use [{ ... }] inside :::blocks.',
+      );
+      if (parsed && parsed.type) blocks.push(parsed);
     }
     return;
   } catch {
     // fall through to recovery
   }
-  const recovered = tryRecoverBareObjects(body);
+  const { blocks: recovered, strategy } = tryRecoverBareObjects(body);
   if (recovered.length > 0) {
+    warnRecovery(
+      strategy,
+      strategy === 'wrap-in-array'
+        ? 'recovered comma-separated objects by wrapping in [ ... ]. Emit a JSON array directly.'
+        : 'recovered multiple bare objects by splitting on }{ boundaries. Emit a JSON array directly.',
+    );
     for (const block of recovered) blocks.push(block);
   } else {
+    warnRecovery(
+      'unparseable-blocks-fence',
+      'body is not valid JSON and could not be recovered — rendering as text.',
+    );
     blocks.push({ type: 'text', content: body });
+  }
+}
+
+function warnRecovery(strategy, message) {
+  if (typeof console !== 'undefined' && console.warn) {
+    console.warn(`[block-parser] :::blocks recovery (${strategy}): ${message}`);
   }
 }
 
@@ -104,6 +127,9 @@ function parseTypedFence(type, body, blocks) {
  * instead of a proper array.  Tries two strategies:
  * 1. Wrap the whole body in [ ... ] (handles comma-separated objects)
  * 2. Split on }{ boundaries and parse each object individually
+ *
+ * Returns { blocks, strategy } where strategy is 'wrap-in-array',
+ * 'split-on-boundary', or 'none' (no blocks recovered).
  */
 function tryRecoverBareObjects(body) {
   // Strategy 1: wrap in brackets
@@ -111,7 +137,10 @@ function tryRecoverBareObjects(body) {
   try {
     const parsed = JSON.parse(wrapped);
     if (Array.isArray(parsed)) {
-      return parsed.filter((b) => b && b.type);
+      const filtered = parsed.filter((b) => b && b.type);
+      if (filtered.length > 0) {
+        return { blocks: filtered, strategy: 'wrap-in-array' };
+      }
     }
   } catch {
     // fall through
@@ -129,5 +158,5 @@ function tryRecoverBareObjects(body) {
       // skip unparseable chunk
     }
   }
-  return results;
+  return { blocks: results, strategy: results.length > 0 ? 'split-on-boundary' : 'none' };
 }


### PR DESCRIPTION
## Summary
The block parser silently recovered from several malformed-block patterns, which masked agent formatting mistakes — output rendered fine, the agent never learned, and groups kept drifting (the rich-output naming churn we saw yesterday in #53 is the same shape of problem). Each recovery path now logs a `console.warn` identifying which strategy fired and what the agent should have emitted instead.

Closes #51

## What changed
`web/js/block-parser.js`:

- **`bare-object-in-blocks-fence`** — single object inside `:::blocks` instead of an array (previously silently auto-wrapped via `Array.isArray(parsed) ? parsed : [parsed]`)
- **`wrap-in-array`** — comma-separated bare objects (previously silently wrapped in `[ ... ]`)
- **`split-on-boundary`** — multiple bare objects without commas (previously silently split on `}{` boundaries)
- **`unparseable-blocks-fence`** — body that couldn't be recovered (previously silently fell back to text)

`tryRecoverBareObjects` now returns `{ blocks, strategy }` so the caller can name which recovery fired in the warning.

Behavior is otherwise unchanged — same blocks rendered for both valid and recoverable input. Only operators with the browser console open will see anything new.

## Out of scope
The issue also suggests a message-level UI indicator and a per-group strict-mode flag. Those are larger and worth their own PR — this slice closes the visibility gap, which was the main driver.

## How it was tested
Smoke-tested all nine paths through Node ESM (browser runs the same module) — verified each recovery emits its warning while non-recovery cases (valid array, plain text, valid shorthand fence) stay quiet. Block counts and types unchanged. Full TS test suite still passes 444/444 (this file isn't imported from TS).

To verify in the browser: open DevTools console, send a message containing a malformed `:::blocks` fence — the warning will appear when the message renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)