### PR TITLE
Show task badge for paused and completed tasks too

### DIFF
--- a/web/js/components/GroupItem.js
+++ b/web/js/components/GroupItem.js
@@ -70,7 +70,22 @@ export function GroupItem({ group, isActive, onSelect, onSettings }) {
   const activeList = activeAgents.value[group.jid] || [];
   const hasActiveAgents = isMultiAgent && activeList.length > 0;
   const groupTasks = tasks.value.filter(t => t.group_folder === group.folder);
-  const taskCount = groupTasks.filter(t => t.status === 'active').length;
+  const activeTaskCount = groupTasks.filter(t => t.status === 'active').length;
+  const pausedTaskCount = groupTasks.filter(t => t.status === 'paused').length;
+  const completedTaskCount = groupTasks.filter(t => t.status === 'completed').length;
+  const hasTasks = groupTasks.length > 0;
+  // Label: lead with whatever's non-zero so paused-only and completed-only
+  // groups still surface a badge the user can click.
+  const taskBadgeLabel = activeTaskCount > 0
+    ? `${activeTaskCount}t`
+    : pausedTaskCount > 0
+      ? `${pausedTaskCount}p`
+      : `${completedTaskCount}✓`;
+  const taskBadgeTooltip = [
+    activeTaskCount > 0 && `${activeTaskCount} active`,
+    pausedTaskCount > 0 && `${pausedTaskCount} paused`,
+    completedTaskCount > 0 && `${completedTaskCount} completed`,
+  ].filter(Boolean).join(', ');
 
   // Auto-expand drawer when specialists activate (don't auto-collapse — that's jarring)
   useEffect(() => {
@@ -124,12 +139,12 @@ export function GroupItem({ group, isActive, onSelect, onSettings }) {
         ${group.isMain && !group.isSystem && html`
           <span class="text-[10px] px-1.5 py-0.5 rounded bg-accent-dim text-accent font-medium shrink-0">main</span>
         `}
-        ${taskCount > 0 && !count && html`
+        ${hasTasks && !count && html`
           <button
-            class="text-[9px] px-1 py-0.5 rounded bg-bg-3 text-txt-muted hover:text-txt hover:bg-bg-hover font-mono shrink-0 ${tasksExpanded ? 'ring-1 ring-accent/40 text-txt' : ''}"
-            title="${taskCount} active task${taskCount > 1 ? 's' : ''} — click to ${tasksExpanded ? 'collapse' : 'expand'}"
+            class="text-[9px] px-1 py-0.5 rounded bg-bg-3 ${activeTaskCount > 0 ? 'text-txt-muted' : 'text-txt-muted/60'} hover:text-txt hover:bg-bg-hover font-mono shrink-0 ${tasksExpanded ? 'ring-1 ring-accent/40 text-txt' : ''}"
+            title="${taskBadgeTooltip} — click to ${tasksExpanded ? 'collapse' : 'expand'}"
             onClick=${handleTasksExpand}
-          >${taskCount}t</button>
+          >${taskBadgeLabel}</button>
         `}
         ${count > 0 && html`
           <span class="min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-accent text-bg text-[11px] font-semibold px-1 shrink-0">


### PR DESCRIPTION
## Summary
Follow-up to #59 (PR #61). The task badge on a group row was gated on \`activeTaskCount > 0\`, which meant any group whose only tasks were paused or completed had no badge — and therefore no way to open the drawer that already knew how to render them. Spotted in production: a group with two paused tasks was unreachable from the sidebar.

## What changed
- Badge now appears whenever the group has any task (active, paused, or completed).
- Label leads with whichever status has tasks: \`Nt\` for active, \`Np\` for paused-only, \`N✓\` for completed-only. Mixed groups keep showing the active count.
- Paused/completed-only badges render slightly dimmer (\`text-txt-muted/60\`) to signal nothing's currently running.
- Tooltip shows the full breakdown — e.g. "2 active, 1 paused, 3 completed — click to expand".
- The drawer body itself was already rendering all statuses (\`TaskItem\` already color-codes the status dot green/yellow/muted), so no drawer changes needed.

## How it was tested
Live-checked locally: a group with 3 completed tasks (web_test-agents) that was previously invisible now shows a \`3✓\` badge that opens the drawer normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)