### PR TITLE
Team creation: runtime per agent + richer default CLAUDE.md

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1212,12 +1212,14 @@ export class WebChannel implements Channel {
           name?: string;
           displayName?: string;
           instructions?: string;
+          runtime?: { provider?: string; model?: string };
         };
         specialists: Array<{
           name: string;
           displayName?: string;
           trigger: string;
           instructions?: string;
+          runtime?: { provider?: string; model?: string };
         }>;
       };
       if (
@@ -1266,6 +1268,56 @@ export class WebChannel implements Channel {
       const groupFolder = `web_${folder}`;
       const groupDir = path.resolve(process.cwd(), 'groups', groupFolder);
 
+      // Build a "first specialist" hint for the coordinator's example.
+      // Falls back to a placeholder if (somehow) no specialists.
+      const exampleSpec = specialists[0];
+      const exampleAgent = exampleSpec
+        ? exampleSpec.name.toLowerCase().replace(/[^a-z0-9_-]/g, '-')
+        : 'specialist';
+
+      const defaultCoordinatorMd = (displayName: string) => `# ${displayName}
+
+You are the coordinator for the ${name} team.
+
+## How to delegate
+
+When a request fits a specialist, **call the tool** — do not narrate what you would do:
+
+\`\`\`
+mcp__nanoclaw__delegate_to_agent({
+  agent: "${exampleAgent}",
+  message: "Specific instructions for the specialist",
+  completion_policy: "final_response"
+})
+\`\`\`
+
+Saying "I'll send this to ${exampleAgent}" without invoking the tool is a bug — the specialist will never run.
+
+## When to respond directly
+
+For general questions that don't fit a specialist, answer yourself.
+
+## Synthesis
+
+When all delegated specialists finish, synthesize their outputs into one response. Don't relay raw specialist output unless it's already final-quality.
+`;
+
+      const defaultSpecialistMd = (
+        displayName: string,
+        trigger: string,
+      ) => `# ${displayName}
+
+You are a specialist on the ${name} team. Your trigger is \`${trigger}\`.
+
+## Your role
+
+Focus on the work the coordinator delegates to you. Respond directly with the answer or artifact — the coordinator will handle synthesis and follow-up.
+
+## Boundaries
+
+You do not delegate. If something falls outside your role, say so plainly in your response and the coordinator will route it.
+`;
+
       // Group-level CLAUDE.md
       fs.mkdirSync(groupDir, { recursive: true });
       fs.writeFileSync(
@@ -1276,18 +1328,20 @@ export class WebChannel implements Channel {
       // Coordinator agent
       const coordDir = path.join(groupDir, 'agents', coordName);
       fs.mkdirSync(coordDir, { recursive: true });
+      const coordDisplayName = coordinator.displayName || 'Coordinator';
       fs.writeFileSync(
         path.join(coordDir, 'CLAUDE.md'),
-        coordinator.instructions ||
-          `# ${coordinator.displayName || 'Coordinator'}\n\nYou are the coordinator for the ${name} team.\n`,
+        coordinator.instructions || defaultCoordinatorMd(coordDisplayName),
       );
+      const coordAgentJson: Record<string, unknown> = {
+        displayName: coordDisplayName,
+      };
+      if (coordinator.runtime && coordinator.runtime.provider) {
+        coordAgentJson.runtime = coordinator.runtime;
+      }
       fs.writeFileSync(
         path.join(coordDir, 'agent.json'),
-        JSON.stringify(
-          { displayName: coordinator.displayName || 'Coordinator' },
-          null,
-          2,
-        ) + '\n',
+        JSON.stringify(coordAgentJson, null, 2) + '\n',
       );
 
       // Specialist agents
@@ -1295,21 +1349,22 @@ export class WebChannel implements Channel {
         const specName = spec.name.toLowerCase().replace(/[^a-z0-9_-]/g, '-');
         const specDir = path.join(groupDir, 'agents', specName);
         fs.mkdirSync(specDir, { recursive: true });
+        const specDisplayName = spec.displayName || spec.name;
         fs.writeFileSync(
           path.join(specDir, 'CLAUDE.md'),
           spec.instructions ||
-            `# ${spec.displayName || spec.name}\n\nYou are a specialist on the ${name} team.\n`,
+            defaultSpecialistMd(specDisplayName, spec.trigger),
         );
+        const specAgentJson: Record<string, unknown> = {
+          displayName: specDisplayName,
+          trigger: spec.trigger,
+        };
+        if (spec.runtime && spec.runtime.provider) {
+          specAgentJson.runtime = spec.runtime;
+        }
         fs.writeFileSync(
           path.join(specDir, 'agent.json'),
-          JSON.stringify(
-            {
-              displayName: spec.displayName || spec.name,
-              trigger: spec.trigger,
-            },
-            null,
-            2,
-          ) + '\n',
+          JSON.stringify(specAgentJson, null, 2) + '\n',
         );
       }
 

--- a/web/js/components/NewGroupDialog.js
+++ b/web/js/components/NewGroupDialog.js
@@ -3,7 +3,20 @@ import { useState, useRef, useEffect } from 'preact/hooks';
 import { createGroup, createTeam } from '../app.js';
 import * as api from '../api.js';
 
-const DEFAULT_SPECIALIST = () => ({ name: '', displayName: '', trigger: '', instructions: '' });
+const DEFAULT_SPECIALIST = () => ({
+  name: '',
+  displayName: '',
+  trigger: '',
+  instructions: '',
+  provider: 'anthropic',
+  model: '',
+});
+const DEFAULT_COORDINATOR = () => ({
+  displayName: 'Coordinator',
+  instructions: '',
+  provider: 'anthropic',
+  model: '',
+});
 
 const TIER_META = {
   beginner: { label: 'Getting Started', desc: 'Learn the basics — each template guides you step by step' },
@@ -53,7 +66,7 @@ export function NewGroupDialog({ open, onClose, initialView = 'pick' }) {
   const [ollamaModels, setOllamaModels] = useState([]);
 
   // Team creation state
-  const [teamCoordinator, setTeamCoordinator] = useState({ displayName: 'Coordinator', instructions: '' });
+  const [teamCoordinator, setTeamCoordinator] = useState(DEFAULT_COORDINATOR());
   const [teamSpecialists, setTeamSpecialists] = useState([DEFAULT_SPECIALIST()]);
 
   useEffect(() => {
@@ -155,7 +168,7 @@ export function NewGroupDialog({ open, onClose, initialView = 'pick' }) {
     setView('pick');
     setProvider('anthropic');
     setModel('');
-    setTeamCoordinator({ displayName: 'Coordinator', instructions: '' });
+    setTeamCoordinator(DEFAULT_COORDINATOR());
     setTeamSpecialists([DEFAULT_SPECIALIST()]);
   }
 
@@ -217,6 +230,16 @@ export function NewGroupDialog({ open, onClose, initialView = 'pick' }) {
     });
   }
 
+  // Build a runtime config payload only when the user picked something
+  // non-default. Anthropic with no model is the platform default, so we
+  // omit it to keep agent.json clean.
+  function buildRuntime(provider, model) {
+    if (provider === 'anthropic' && !model) return undefined;
+    const out = { provider };
+    if (model) out.model = model;
+    return out;
+  }
+
   function addSpecialist() {
     setTeamSpecialists((prev) => [...prev, DEFAULT_SPECIALIST()]);
   }
@@ -236,12 +259,17 @@ export function NewGroupDialog({ open, onClose, initialView = 'pick' }) {
       await createTeam({
         name: name.trim(),
         folder: folder.trim(),
-        coordinator: teamCoordinator,
+        coordinator: {
+          displayName: teamCoordinator.displayName,
+          instructions: teamCoordinator.instructions,
+          runtime: buildRuntime(teamCoordinator.provider, teamCoordinator.model),
+        },
         specialists: validSpecs.map((s) => ({
           name: s.name.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-'),
           displayName: s.displayName.trim() || s.name.trim(),
           trigger: s.trigger.trim(),
           instructions: s.instructions.trim(),
+          runtime: buildRuntime(s.provider, s.model),
         })),
       });
       resetForm();
@@ -599,6 +627,13 @@ export function NewGroupDialog({ open, onClose, initialView = 'pick' }) {
               value=${teamCoordinator.displayName}
               onInput=${(e) => setTeamCoordinator((prev) => ({ ...prev, displayName: e.target.value }))}
             />
+            ${renderProviderModelRow(
+              teamCoordinator.provider,
+              (v) => setTeamCoordinator((prev) => ({ ...prev, provider: v })),
+              teamCoordinator.model,
+              (v) => setTeamCoordinator((prev) => ({ ...prev, model: v })),
+              'Coordinator',
+            )}
             <textarea
               class="bg-bg-3 border border-border rounded-lg px-3 py-2 text-sm text-txt focus:outline-none focus:border-accent resize-none"
               rows="2"
@@ -657,6 +692,13 @@ export function NewGroupDialog({ open, onClose, initialView = 'pick' }) {
                   value=${spec.displayName}
                   onInput=${(e) => updateSpecialist(i, 'displayName', e.target.value)}
                 />
+                ${renderProviderModelRow(
+                  spec.provider,
+                  (v) => updateSpecialist(i, 'provider', v),
+                  spec.model,
+                  (v) => updateSpecialist(i, 'model', v),
+                  'Specialist',
+                )}
                 <textarea
                   class="bg-bg border border-border rounded-lg px-3 py-1.5 text-sm text-txt focus:outline-none focus:border-accent resize-none"
                   rows="2"


### PR DESCRIPTION
## Summary
Fixes two gaps in the team-create flow surfaced while debugging a multi-agent test team:

1. **No runtime picker in the team UI.** The single-agent flow had a provider/model row; the team flow didn't. Teams were created with no runtime config, forcing users to edit each agent afterwards.
2. **Thin default CLAUDE.md.** When the user left "Instructions" blank (the common case), both coordinator and specialist got a 3-line stub. The auto-injected multi-agent context already carried delegation guidance — but model nondeterminism meant coordinators sometimes **narrated** delegation ("I'll send this to X") instead of **invoking** the tool. In a scheduled-task test, 1 of 3 delegations actually landed.

## What changed

### `web/js/components/NewGroupDialog.js`
- Team form now renders the existing `renderProviderModelRow` for the coordinator and every specialist.
- `DEFAULT_COORDINATOR()` / `DEFAULT_SPECIALIST()` carry `provider` + `model` alongside existing fields.
- A small `buildRuntime()` helper only sends `runtime` to the server when the user picked something non-default (keeps `agent.json` clean when "Anthropic / no model" is selected).

### `src/channels/web.ts` — `POST /api/teams`
- Accepts an optional `runtime: { provider, model }` on coordinator + each specialist.
- Writes it into `agent.json` only when `provider` is present.
- Default CLAUDE.md (used when the user's `instructions` is blank) is now **rich**:
  - **Coordinator**: role + concrete \`delegate_to_agent\` example using the first specialist's *actual name* + "describing is not invoking" rule.
  - **Specialist**: role + "you do not delegate, the coordinator handles routing" boundary.

Belt-and-suspenders with `buildMultiAgentContext` — same rules, now also in the agent's own persona.

## Why two gaps in one PR
They share the same surface (team-create form + POST /api/teams) and both bite anyone using the multi-agent UI. Splitting them would mean touching the same `agent.json` write in two PRs.

## How it was tested
- Created a test team via \`POST /api/teams\` with mixed runtimes (Anthropic coordinator, Ollama specialist with model, one specialist with no runtime). Confirmed each \`agent.json\` got exactly what was sent; no-runtime case omits the field cleanly.
- Inspected generated CLAUDE.md files — coordinator includes a real specialist name in the delegate example, specialist gets the role boundary.
- User verified the UI renders provider/model rows on both coordinator and specialist cards.
- Full test suite: 453/453 passing.

## Follow-up
Filed #65 — "Elevate auto-injected multi-agent context as the load-bearing reliability layer." The richer CLAUDE.md in this PR reinforces reliability in the agent's own voice, but the *platform* layer (\`buildMultiAgentContext\`) should carry reliability on its own rather than depending on every author's CLAUDE.md saying the right things. That's the bigger architectural arc and ties to #46, #50, and #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)