### PR TITLE
Fix Ollama token-per-message streaming + agent-runner cache-check

### DIFF
--- a/container/agent-runner/src/ollama-runtime.ts
+++ b/container/agent-runner/src/ollama-runtime.ts
@@ -220,13 +220,12 @@ export class OllamaRuntime {
 
           if (chunk.message?.content) {
             if (!firstTokenTime) firstTokenTime = Date.now();
-            const token = chunk.message.content;
-            fullText += token;
-            yield {
-              type: 'text',
-              text: token,
-              timestamp: new Date().toISOString(),
-            };
+            // Buffer tokens into fullText and let the final `result` yield
+            // deliver the whole message at once. Yielding per-token text
+            // events produces one chat message per token downstream — the
+            // intermediate-text pathway was designed for Claude's paragraph-
+            // sized chunks, not per-token streams.
+            fullText += chunk.message.content;
           }
 
           if (chunk.done) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -326,18 +326,27 @@ function buildVolumeMounts(
     'agent-runner-src',
   );
   if (fs.existsSync(agentRunnerSrc)) {
-    const srcIndex = path.join(agentRunnerSrc, 'index.ts');
-    const cachedIndex = path.join(groupAgentRunnerDir, 'index.ts');
-    const srcStat = fs.existsSync(srcIndex) ? fs.statSync(srcIndex) : null;
-    const cachedStat = fs.existsSync(cachedIndex)
-      ? fs.statSync(cachedIndex)
-      : null;
+    // Compare the newest mtime across every file in src, not just index.ts.
+    // Sibling-file edits (e.g. ollama-runtime.ts) were otherwise ignored by
+    // warm groups, serving stale agent-runner code until something touched
+    // index.ts.
+    const latestMtime = (dir: string): number => {
+      let newest = 0;
+      if (!fs.existsSync(dir)) return newest;
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          newest = Math.max(newest, latestMtime(full));
+        } else if (entry.isFile()) {
+          newest = Math.max(newest, fs.statSync(full).mtimeMs);
+        }
+      }
+      return newest;
+    };
+    const srcMtime = latestMtime(agentRunnerSrc);
+    const cachedMtime = latestMtime(groupAgentRunnerDir);
     const needsCopy =
-      !fs.existsSync(groupAgentRunnerDir) ||
-      !cachedStat ||
-      !srcStat ||
-      srcStat.mtimeMs > cachedStat.mtimeMs ||
-      srcStat.size !== cachedStat.size;
+      !fs.existsSync(groupAgentRunnerDir) || srcMtime > cachedMtime;
     if (needsCopy) {
       fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary
Two related bugs that surfaced while retesting multi-agent delegation after #66:

1. **Ollama specialists were emitting one chat message per token.** A specialist's single sentence became 30+ one-word messages in the chat.
2. **agent-runner cache-check was blind to sibling-file edits.** Only checked \`index.ts\`'s mtime, so any change to \`ollama-runtime.ts\` / \`claude-runtime.ts\` / other siblings was silently ignored by warm groups until something touched \`index.ts\`.

Both land in one PR because fix #2 is required for fix #1 to actually deploy.

## Bug 1: Ollama token-per-message streaming
\`ollama-runtime.ts\` was yielding \`{ type: 'text', text: token }\` for **every streaming token** from Ollama. That pathway was designed for Claude's paragraph-sized intermediate chunks — for Ollama it meant each token became a TEXT marker → became an \`onText\` callback → became a \`sendMessage\` → became its own DB row.

**Before** (actual logs from a test run):
\`\`\`
17:50:04.930  respective
17:50:04.998  specialist
17:50:05.048  ,
17:50:05.099  and
...
17:50:05.600  .
\`\`\`

**After**:
> "I'm One, a specialist here on Test Agents focused on reviewing flags and drafting summaries."
> — one message, 92 chars

**Fix:** buffer tokens into \`fullText\` as before, but don't yield the intermediate per-token events. The final \`result\` yield with \`textsAlreadyStreamed: 0\` delivers the whole message as one sendMessage.

## Bug 2: agent-runner cache-check only looked at index.ts
The host copies \`container/agent-runner/src/\` into each group's \`data/sessions/{group}/agent-runner-src/\` and compares mtime to skip redundant copies. The comparison only looked at \`index.ts\` — sibling edits were invisible to this check, so groups with a warm cache served stale code indefinitely.

**Fix:** walk the source tree and compare the newest mtime across every file. Verified by watching the test-agents specialist pick up the Ollama fix on the next spawn (cached \`yield {\` count went from 6 → 5, matching the ollama-runtime change).

## How it was tested
- Live-sent a message triggering delegation to an Ollama specialist.
- Confirmed specialist produced exactly 1 coherent message instead of per-token fragments.
- Confirmed cache-check detected the \`ollama-runtime.ts\` edit and re-copied to the active group's cache.
- Full TS test suite: 453/453 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)