### PR TITLE
Render ConfirmDialog via native <dialog> to escape transform ancestors

### DIFF
--- a/web/js/components/ConfirmDialog.js
+++ b/web/js/components/ConfirmDialog.js
@@ -4,6 +4,12 @@ import { useState, useEffect, useRef } from 'preact/hooks';
 /**
  * Reusable confirmation dialog.
  *
+ * Uses the native <dialog> element with showModal() so the modal is
+ * rendered in the browser's top layer — this is required to escape
+ * transform/filter ancestors (e.g. the sidebar <aside>) that would
+ * otherwise contain `position: fixed` children and leave the dialog
+ * squished inside the sidebar column.
+ *
  * Props:
  *   open        - boolean, controls visibility
  *   title       - dialog heading
@@ -27,17 +33,35 @@ export function ConfirmDialog({
   onCancel,
 }) {
   const [typed, setTyped] = useState('');
+  const dialogRef = useRef(null);
   const inputRef = useRef(null);
 
-  // Reset typed text when dialog opens/closes
+  // Sync open prop → native dialog open state via showModal/close
   useEffect(() => {
-    setTyped('');
-    if (open && confirmText && inputRef.current) {
-      setTimeout(() => inputRef.current?.focus(), 50);
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (open && !dlg.open) {
+      dlg.showModal();
+      setTyped('');
+      if (confirmText) {
+        setTimeout(() => inputRef.current?.focus(), 50);
+      }
+    } else if (!open && dlg.open) {
+      dlg.close();
     }
   }, [open, confirmText]);
 
-  if (!open) return null;
+  // Native dialog's ESC triggers a 'cancel' event — forward it
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    const handleCancel = (e) => {
+      e.preventDefault();
+      if (!loading) onCancel?.();
+    };
+    dlg.addEventListener('cancel', handleCancel);
+    return () => dlg.removeEventListener('cancel', handleCancel);
+  }, [loading, onCancel]);
 
   const canConfirm = confirmText ? typed === confirmText : true;
 
@@ -45,42 +69,50 @@ export function ConfirmDialog({
     ? 'px-3 py-1.5 text-xs font-semibold text-white bg-red-500 rounded-lg hover:bg-red-600 disabled:opacity-40 transition-colors'
     : 'px-3 py-1.5 text-xs font-semibold text-white bg-accent rounded-lg hover:opacity-90 disabled:opacity-40 transition-colors';
 
+  // Click on the dialog's own backdrop (not the inner panel) cancels.
+  // e.target === dialog means the click was on the backdrop area.
+  function handleBackdropClick(e) {
+    if (e.target === dialogRef.current && !loading) onCancel?.();
+  }
+
   return html`
-    <div class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" onClick=${onCancel}>
-      <div class="bg-bg-2 border border-border rounded-xl p-6 w-[360px] shadow-xl" onClick=${(e) => e.stopPropagation()}>
-        <h3 class="text-sm font-semibold text-txt mb-2">${title}</h3>
-        <p class="text-xs text-txt-2 mb-4">${message}</p>
-        ${confirmText && html`
-          <div class="mb-4">
-            <p class="text-xs text-txt-2 mb-2">
-              Type <span class="font-mono font-semibold text-txt">${confirmText}</span> to confirm:
-            </p>
-            <input
-              ref=${inputRef}
-              type="text"
-              class="w-full px-3 py-1.5 text-xs bg-bg border border-border rounded-lg text-txt focus:outline-none focus:border-accent"
-              value=${typed}
-              onInput=${(e) => setTyped(e.target.value)}
-              placeholder=${confirmText}
-              disabled=${loading}
-              autocomplete="off"
-              spellcheck="false"
-            />
-          </div>
-        `}
-        <div class="flex justify-end gap-2">
-          <button
-            class="px-3 py-1.5 text-xs text-txt-2 hover:text-txt rounded-lg hover:bg-bg-hover transition-colors"
-            onClick=${onCancel}
+    <dialog
+      ref=${dialogRef}
+      class="bg-bg-2 text-txt border border-border rounded-xl p-6 w-[360px] shadow-xl backdrop:bg-black/50"
+      onClick=${handleBackdropClick}
+    >
+      <h3 class="text-sm font-semibold text-txt mb-2">${title}</h3>
+      <p class="text-xs text-txt-2 mb-4">${message}</p>
+      ${confirmText && html`
+        <div class="mb-4">
+          <p class="text-xs text-txt-2 mb-2">
+            Type <span class="font-mono font-semibold text-txt">${confirmText}</span> to confirm:
+          </p>
+          <input
+            ref=${inputRef}
+            type="text"
+            class="w-full px-3 py-1.5 text-xs bg-bg border border-border rounded-lg text-txt focus:outline-none focus:border-accent"
+            value=${typed}
+            onInput=${(e) => setTyped(e.target.value)}
+            placeholder=${confirmText}
             disabled=${loading}
-          >Cancel</button>
-          <button
-            class=${confirmBtnClass}
-            onClick=${onConfirm}
-            disabled=${loading || !canConfirm}
-          >${loading ? 'Working...' : confirmLabel}</button>
+            autocomplete="off"
+            spellcheck="false"
+          />
         </div>
+      `}
+      <div class="flex justify-end gap-2">
+        <button
+          class="px-3 py-1.5 text-xs text-txt-2 hover:text-txt rounded-lg hover:bg-bg-hover transition-colors"
+          onClick=${onCancel}
+          disabled=${loading}
+        >Cancel</button>
+        <button
+          class=${confirmBtnClass}
+          onClick=${onConfirm}
+          disabled=${loading || !canConfirm}
+        >${loading ? 'Working...' : confirmLabel}</button>
       </div>
-    </div>
+    </dialog>
   `;
 }


### PR DESCRIPTION
## Summary
The task-delete confirm dialog was rendering squished inside the sidebar column (~280px wide) instead of centered over the page.

## Root cause
The sidebar \`<aside>\` uses Tailwind's \`transform transition-transform\` utilities so it can slide in/out on mobile. A \`position: fixed\` descendant of a \`transform\` ancestor anchors to that ancestor, not the viewport (CSS containing-block rule). \`TaskItem\`'s \`ConfirmDialog\` renders naturally inside the sidebar tree, so it got trapped.

\`GroupSettings\`'s dialog works because Sidebar renders it as a sibling of the \`<aside>\` — outside the transform ancestor. That workaround doesn't scale (every dialog-owning component would need to lift state up to the Sidebar level).

## Fix
Convert \`ConfirmDialog\` to the native \`<dialog>\` element with \`showModal()\`. Native dialogs render in the browser top layer, which bypasses transform/filter containment by design. Same pattern \`NewGroupDialog\` already uses.

Props API is unchanged — the three callers (\`ChatView\`, \`TaskItem\`, \`GroupSettings\`) work as-is.

## Bonus wins from going native
- ESC-to-close (was not implemented before)
- Focus trapping within the dialog (was not implemented before)
- \`::backdrop\` pseudo-element for the overlay (no more manual \`<div class="fixed inset-0 bg-black/50">\`)

## How it was tested
Live-verified: clicked delete on a task inside a sidebar group; dialog now centers over the full viewport. Clicking the backdrop cancels, ESC cancels, typed-confirm flow still works for group delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)