### PR TITLE
Capability matrix + stop telling tool-less agents about MCP tools

### DIFF
--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -9,6 +9,7 @@ import path from 'path';
 
 import { resolveGroupFolderPath } from './group-folder.js';
 import { logger } from './logger.js';
+import { getCapabilityProfile } from './model-capabilities.js';
 import { AgentRuntimeConfig } from './runtime-types.js';
 import { Agent, ContainerConfig, RegisteredGroup } from './types.js';
 
@@ -146,6 +147,13 @@ export function resolveAgentClaudeMdPath(agent: Agent): string {
 /**
  * Build a multi-agent context block that gets injected into prompts.
  * Tells the agent who it is, who else is in the group, and how handoffs work.
+ *
+ * Branches on the agent's capability profile: tool-capable runtimes
+ * (Claude) get the full MCP-based protocol; tool-less runtimes (Ollama
+ * today) get a text-only variant that describes the implicit protocol
+ * the host actually uses (final text → delivered as user message).
+ * Telling a tool-less agent about MCP tools is misinformation — it wastes
+ * tokens and produces narration-of-tool-calls instead of real responses.
  */
 export function buildMultiAgentContext(
   currentAgent: Agent,
@@ -159,6 +167,7 @@ export function buildMultiAgentContext(
     .join('\n');
 
   const isCoordinator = !currentAgent.trigger;
+  const profile = getCapabilityProfile(currentAgent.runtime);
 
   const lines = [
     `--- Multi-agent group context ---`,
@@ -169,36 +178,58 @@ export function buildMultiAgentContext(
   ];
 
   if (isCoordinator) {
-    lines.push(
-      `You are the coordinator. You handle general questions directly and delegate specialist work.`,
-      `For meaningful ongoing work, keep sidebar presence current: use mcp__nanoclaw__set_subtitle for the team-level summary, and use mcp__nanoclaw__set_agent_status for your own row if you have one.`,
-      `Set concise, high-signal statuses when work starts ("Reviewing PRs", "Waiting on Scout") and clear them when the work is done.`,
-      `To delegate, use the mcp__nanoclaw__delegate_to_agent tool:`,
-      `  delegate_to_agent({ agent: "${others[0]?.name || 'agent'}", message: "Specific instructions...", completion_policy: "final_response" })`,
-      `Use completion_policy: "final_response" by default. Only use "retrigger_coordinator" when you specifically need a follow-up turn to combine or interpret specialist results.`,
-      `The target agent runs after your turn. Their user-visible output may be suppressed if newer context arrives before it is delivered.`,
-      `Even when a specialist's user-visible output is suppressed, the system records that completion for you in the conversation so you can decide whether to reuse it, summarize it, or move on.`,
-      `Avoid over-narrating future delegation steps to the user. If the conversation changes direction, treat older delegated work as possibly superseded and respond to the newest context.`,
-      `Be specific in your delegation message — tell the agent exactly what to do and what context it needs.`,
-      `Artifacts should be written under a dedicated subdirectory of /workspace/group/ (for example /workspace/group/artifacts/ or /workspace/group/uploads/) so all agents can access them without cluttering the group root.`,
-      `If browser automation or visual review matters, prefer surfacing a screenshot with mcp__nanoclaw__publish_browser_snapshot or mcp__nanoclaw__publish_media instead of only describing the page in text.`,
-      `If the user explicitly asks to see the page or asks "what do you see?", treat that as a strong cue to publish a browser snapshot.`,
-      `If delegated browser work hits a blocker like a login wall, captcha, modal trap, missing control, or broken layout, publish one screenshot with a short caption before asking for guidance.`,
-      ``,
-      `Silent chaining: when a specialist just finished and you are simply passing the baton to the next one in a sequence, delegate without a visible message. Only respond visibly when synthesizing results, making a decision, or all specialists in the current batch have reported back. Do not narrate each handoff.`,
-    );
+    if (profile.receivesMcpTools) {
+      lines.push(
+        `You are the coordinator. You handle general questions directly and delegate specialist work.`,
+        `For meaningful ongoing work, keep sidebar presence current: use mcp__nanoclaw__set_subtitle for the team-level summary, and use mcp__nanoclaw__set_agent_status for your own row if you have one.`,
+        `Set concise, high-signal statuses when work starts ("Reviewing PRs", "Waiting on Scout") and clear them when the work is done.`,
+        `To delegate, use the mcp__nanoclaw__delegate_to_agent tool:`,
+        `  delegate_to_agent({ agent: "${others[0]?.name || 'agent'}", message: "Specific instructions...", completion_policy: "final_response" })`,
+        `Use completion_policy: "final_response" by default. Only use "retrigger_coordinator" when you specifically need a follow-up turn to combine or interpret specialist results.`,
+        `The target agent runs after your turn. Their user-visible output may be suppressed if newer context arrives before it is delivered.`,
+        `Even when a specialist's user-visible output is suppressed, the system records that completion for you in the conversation so you can decide whether to reuse it, summarize it, or move on.`,
+        `Avoid over-narrating future delegation steps to the user. If the conversation changes direction, treat older delegated work as possibly superseded and respond to the newest context.`,
+        `Be specific in your delegation message — tell the agent exactly what to do and what context it needs.`,
+        `Artifacts should be written under a dedicated subdirectory of /workspace/group/ (for example /workspace/group/artifacts/ or /workspace/group/uploads/) so all agents can access them without cluttering the group root.`,
+        `If browser automation or visual review matters, prefer surfacing a screenshot with mcp__nanoclaw__publish_browser_snapshot or mcp__nanoclaw__publish_media instead of only describing the page in text.`,
+        `If the user explicitly asks to see the page or asks "what do you see?", treat that as a strong cue to publish a browser snapshot.`,
+        `If delegated browser work hits a blocker like a login wall, captcha, modal trap, missing control, or broken layout, publish one screenshot with a short caption before asking for guidance.`,
+        ``,
+        `Silent chaining: when a specialist just finished and you are simply passing the baton to the next one in a sequence, delegate without a visible message. Only respond visibly when synthesizing results, making a decision, or all specialists in the current batch have reported back. Do not narrate each handoff.`,
+      );
+    } else {
+      // Tool-less coordinator: can't actually delegate. Be honest about the
+      // limitation so the model doesn't produce narration-of-delegation.
+      lines.push(
+        `You are the coordinator. Your runtime does not have tool-calling access, so you cannot delegate work programmatically — answer directly from your own knowledge.`,
+        `If a question is clearly within another agent's specialty, say so in your response; the user can re-route by @-mentioning that agent explicitly.`,
+        `Respond in plain text. Whatever you write will be delivered to the user as your message.`,
+      );
+    }
   } else {
-    lines.push(
-      `You are a specialist. Focus on your role and respond directly.`,
-      `For meaningful ongoing work, set your own sidebar status with mcp__nanoclaw__set_agent_status using a short phrase like "Reviewing flags" or "Drafting summary", then clear it when you are done.`,
-      `If work falls outside your expertise, say so in your response — the coordinator will handle routing.`,
-      `Your response may be superseded for user delivery if newer context arrives first. Complete the assigned work cleanly anyway; the coordinator will still see that you finished.`,
-      `Do NOT try to act as other agents or delegate work yourself.`,
-      `Write any artifacts under a dedicated subdirectory of /workspace/group/ (for example /workspace/group/artifacts/ or /workspace/group/uploads/) so other agents can access them without cluttering the group root.`,
-      `If visual context would help the user, publish a screenshot or image rather than only describing it in text.`,
-      `If the user explicitly asks to see the page or asks "what do you see?", prefer publishing a browser snapshot.`,
-      `If browser work hits a blocker like a login wall, captcha, modal trap, missing control, or broken layout, publish one screenshot with a short caption before asking for help.`,
-    );
+    // Specialist.
+    if (profile.receivesMcpTools) {
+      lines.push(
+        `You are a specialist. Focus on your role and respond directly.`,
+        `For meaningful ongoing work, set your own sidebar status with mcp__nanoclaw__set_agent_status using a short phrase like "Reviewing flags" or "Drafting summary", then clear it when you are done.`,
+        `If work falls outside your expertise, say so in your response — the coordinator will handle routing.`,
+        `Your response may be superseded for user delivery if newer context arrives first. Complete the assigned work cleanly anyway; the coordinator will still see that you finished.`,
+        `Do NOT try to act as other agents or delegate work yourself.`,
+        `Write any artifacts under a dedicated subdirectory of /workspace/group/ (for example /workspace/group/artifacts/ or /workspace/group/uploads/) so other agents can access them without cluttering the group root.`,
+        `If visual context would help the user, publish a screenshot or image rather than only describing it in text.`,
+        `If the user explicitly asks to see the page or asks "what do you see?", prefer publishing a browser snapshot.`,
+        `If browser work hits a blocker like a login wall, captcha, modal trap, missing control, or broken layout, publish one screenshot with a short caption before asking for help.`,
+      );
+    } else {
+      // Tool-less specialist: the whole reply text becomes the user-visible
+      // message via the host's text-path fallback. No MCP tools, no status.
+      lines.push(
+        `You are a specialist. Focus on your role and respond directly.`,
+        `Respond in plain text — your entire reply will be delivered to the user as your message. You do not have tools or status controls, so keep the response self-contained.`,
+        `If a request falls outside your expertise, say so briefly; the coordinator will handle routing.`,
+        `Do not try to act as other agents or delegate work yourself.`,
+      );
+    }
   }
 
   lines.push(`--- End multi-agent context ---`, ``);

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -12,7 +12,9 @@ import {
   compareRuntimeProfiles,
   resolveRuntimeProfile,
 } from '../runtime-profile.js';
+import { getCapabilityProfile } from '../model-capabilities.js';
 import { resolveEffectiveRuntime } from '../runtime-resolution.js';
+import type { AgentRuntimeConfig } from '../runtime-types.js';
 import {
   getAchievementResponse,
   checkTelemetryAchievements,
@@ -1275,7 +1277,27 @@ export class WebChannel implements Channel {
         ? exampleSpec.name.toLowerCase().replace(/[^a-z0-9_-]/g, '-')
         : 'specialist';
 
-      const defaultCoordinatorMd = (displayName: string) => `# ${displayName}
+      // Default CLAUDE.md content branches on whether the agent's runtime
+      // actually receives MCP tools today. Ollama (and any non-Claude
+      // runtime) gets a text-only variant — telling a tool-less agent to
+      // "call the tool" produces narration-of-tool-calls, not real work.
+      const defaultCoordinatorMd = (
+        displayName: string,
+        receivesMcpTools: boolean,
+      ) => {
+        if (!receivesMcpTools) {
+          return `# ${displayName}
+
+You are the coordinator for the ${name} team.
+
+Your runtime does not have tool-calling access, so you cannot delegate work programmatically. Answer user requests directly from your own knowledge.
+
+If a question is clearly within another agent's specialty, say so and point the user at the specialist's trigger (e.g. \`@${exampleAgent}\`) — they can re-route the request themselves.
+
+Your plain-text reply is delivered as the user-visible message.
+`;
+        }
+        return `# ${displayName}
 
 You are the coordinator for the ${name} team.
 
@@ -1301,11 +1323,28 @@ For general questions that don't fit a specialist, answer yourself.
 
 When all delegated specialists finish, synthesize their outputs into one response. Don't relay raw specialist output unless it's already final-quality.
 `;
+      };
 
       const defaultSpecialistMd = (
         displayName: string,
         trigger: string,
-      ) => `# ${displayName}
+        receivesMcpTools: boolean,
+      ) => {
+        if (!receivesMcpTools) {
+          return `# ${displayName}
+
+You are a specialist on the ${name} team. Your trigger is \`${trigger}\`.
+
+## Your role
+
+When the coordinator delegates work to you, respond in plain text. Your entire reply is delivered to the user as your message, so keep it self-contained.
+
+## Boundaries
+
+You do not have tools, sidebar controls, or the ability to delegate. If a request falls outside your role, say so plainly — the coordinator will route it.
+`;
+        }
+        return `# ${displayName}
 
 You are a specialist on the ${name} team. Your trigger is \`${trigger}\`.
 
@@ -1317,6 +1356,7 @@ Focus on the work the coordinator delegates to you. Respond directly with the an
 
 You do not delegate. If something falls outside your role, say so plainly in your response and the coordinator will route it.
 `;
+      };
 
       // Group-level CLAUDE.md
       fs.mkdirSync(groupDir, { recursive: true });
@@ -1329,9 +1369,13 @@ You do not delegate. If something falls outside your role, say so plainly in you
       const coordDir = path.join(groupDir, 'agents', coordName);
       fs.mkdirSync(coordDir, { recursive: true });
       const coordDisplayName = coordinator.displayName || 'Coordinator';
+      const coordProfile = getCapabilityProfile(
+        coordinator.runtime as AgentRuntimeConfig | undefined,
+      );
       fs.writeFileSync(
         path.join(coordDir, 'CLAUDE.md'),
-        coordinator.instructions || defaultCoordinatorMd(coordDisplayName),
+        coordinator.instructions ||
+          defaultCoordinatorMd(coordDisplayName, coordProfile.receivesMcpTools),
       );
       const coordAgentJson: Record<string, unknown> = {
         displayName: coordDisplayName,
@@ -1350,10 +1394,17 @@ You do not delegate. If something falls outside your role, say so plainly in you
         const specDir = path.join(groupDir, 'agents', specName);
         fs.mkdirSync(specDir, { recursive: true });
         const specDisplayName = spec.displayName || spec.name;
+        const specProfile = getCapabilityProfile(
+          spec.runtime as AgentRuntimeConfig | undefined,
+        );
         fs.writeFileSync(
           path.join(specDir, 'CLAUDE.md'),
           spec.instructions ||
-            defaultSpecialistMd(specDisplayName, spec.trigger),
+            defaultSpecialistMd(
+              specDisplayName,
+              spec.trigger,
+              specProfile.receivesMcpTools,
+            ),
         );
         const specAgentJson: Record<string, unknown> = {
           displayName: specDisplayName,

--- a/src/model-capabilities.test.ts
+++ b/src/model-capabilities.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCapabilityProfile } from './model-capabilities.js';
+import { buildMultiAgentContext } from './agent-discovery.js';
+import type { Agent } from './types.js';
+
+describe('getCapabilityProfile', () => {
+  it('returns the anthropic profile when runtime is undefined (platform default)', () => {
+    const p = getCapabilityProfile(undefined);
+    expect(p.receivesMcpTools).toBe(true);
+    expect(p.streaming).toBe('chunked');
+  });
+
+  it('returns the anthropic profile for explicit anthropic', () => {
+    const p = getCapabilityProfile({ provider: 'anthropic' });
+    expect(p.receivesMcpTools).toBe(true);
+  });
+
+  it('reports ollama as tool-less — the adapter does not pass tools today', () => {
+    const p = getCapabilityProfile({ provider: 'ollama', model: 'qwen3.5:4b' });
+    expect(p.receivesMcpTools).toBe(false);
+    expect(p.streaming).toBe('per-token');
+  });
+
+  it('falls back to a tool-less profile for not-yet-wired providers', () => {
+    const p = getCapabilityProfile({ provider: 'openai' });
+    expect(p.receivesMcpTools).toBe(false);
+  });
+});
+
+function agent(overrides: Partial<Agent>): Agent {
+  return {
+    id: 'web_team/x',
+    groupFolder: 'web_team',
+    name: 'x',
+    displayName: 'X',
+    ...overrides,
+  };
+}
+
+describe('buildMultiAgentContext', () => {
+  const coord = agent({
+    id: 'web_team/coord',
+    name: 'coord',
+    displayName: 'Coord',
+  });
+  const spec = agent({
+    id: 'web_team/spec',
+    name: 'spec',
+    displayName: 'Spec',
+    trigger: '@spec',
+  });
+
+  it('returns empty when the group has a single agent', () => {
+    expect(buildMultiAgentContext(coord, [coord])).toBe('');
+  });
+
+  it('tool-capable coordinator gets the full MCP delegation protocol', () => {
+    const out = buildMultiAgentContext(coord, [coord, spec]);
+    expect(out).toContain('mcp__nanoclaw__delegate_to_agent');
+    expect(out).toContain('mcp__nanoclaw__set_subtitle');
+  });
+
+  it('tool-less coordinator gets a text-only protocol with no MCP references', () => {
+    const ollamaCoord = agent({
+      ...coord,
+      runtime: { provider: 'ollama', model: 'qwen3.5:4b' },
+    });
+    const out = buildMultiAgentContext(ollamaCoord, [ollamaCoord, spec]);
+    expect(out).not.toContain('mcp__nanoclaw__');
+    expect(out).toContain('does not have tool-calling access');
+    expect(out).toContain('cannot delegate');
+  });
+
+  it('tool-capable specialist gets MCP status + protocol references', () => {
+    const out = buildMultiAgentContext(spec, [coord, spec]);
+    expect(out).toContain('mcp__nanoclaw__set_agent_status');
+  });
+
+  it('tool-less specialist description is plain-text-only', () => {
+    const ollamaSpec = agent({
+      ...spec,
+      runtime: { provider: 'ollama', model: 'llama3.2:1b' },
+    });
+    const out = buildMultiAgentContext(ollamaSpec, [coord, ollamaSpec]);
+    expect(out).not.toContain('mcp__nanoclaw__');
+    expect(out).toContain('plain text');
+    expect(out).toContain('delivered to the user');
+  });
+
+  it('lists teammates regardless of capability profile', () => {
+    const ollamaSpec = agent({
+      ...spec,
+      runtime: { provider: 'ollama' },
+    });
+    const out = buildMultiAgentContext(ollamaSpec, [coord, ollamaSpec]);
+    expect(out).toContain('Coord');
+  });
+});

--- a/src/model-capabilities.ts
+++ b/src/model-capabilities.ts
@@ -1,0 +1,69 @@
+/**
+ * Static capability matrix per (provider, model).
+ *
+ * Today this is a curated table — there is no probing yet. The goal is to
+ * have one place in code that answers "what can this runtime actually do
+ * for us today?" so context injection, UI warnings, and runtime governance
+ * can all consult the same source of truth.
+ *
+ * Important distinction: this reports *effective* capabilities given the
+ * orchestrator plumbing we have today, not the model's theoretical maximum.
+ * Ollama models that advertise `tools: true` via `/api/show` still return
+ * `receivesMcpTools: false` here because the Ollama runtime adapter does
+ * not currently pass a `tools` array to `/api/chat`. Wiring that up is
+ * Phase 4b of #69 — until then, telling an Ollama agent about MCP tools
+ * is misinformation regardless of what model it runs.
+ */
+
+import type { AgentRuntimeConfig } from './runtime-types.js';
+
+export interface CapabilityProfile {
+  /**
+   * True iff the runtime adapter actually passes MCP tools to the model.
+   * Drives whether platform-injected context should mention MCP tool
+   * invocations. If false, the agent responds in plain text and the host
+   * delivers that text as the user-visible message.
+   */
+  receivesMcpTools: boolean;
+
+  /**
+   * Shape of streamed content emitted to the host. `per-token` means the
+   * host must buffer before emitting a chat message (otherwise you get one
+   * DB row per token). `chunked` is paragraph-sized pieces. `whole` means
+   * only a final full message, no streaming.
+   */
+  streaming: 'per-token' | 'chunked' | 'whole';
+}
+
+const ANTHROPIC_PROFILE: CapabilityProfile = {
+  receivesMcpTools: true,
+  streaming: 'chunked',
+};
+
+// Ollama: adapter currently doesn't pass a tools array, so no MCP tools
+// reach any Ollama model. Streaming is per-token; the host buffers.
+const OLLAMA_PROFILE: CapabilityProfile = {
+  receivesMcpTools: false,
+  streaming: 'per-token',
+};
+
+// Safe default for providers we haven't wired yet. Assume text-only so
+// platform context doesn't lie about tools that aren't plumbed.
+const UNSUPPORTED_PROFILE: CapabilityProfile = {
+  receivesMcpTools: false,
+  streaming: 'whole',
+};
+
+/**
+ * Look up the capability profile for a runtime config. When runtime is
+ * undefined or uses a provider the orchestrator treats as Claude-native
+ * (the platform default), returns the Anthropic profile.
+ */
+export function getCapabilityProfile(
+  runtime: AgentRuntimeConfig | undefined,
+): CapabilityProfile {
+  const provider = runtime?.provider;
+  if (!provider || provider === 'anthropic') return ANTHROPIC_PROFILE;
+  if (provider === 'ollama') return OLLAMA_PROFILE;
+  return UNSUPPORTED_PROFILE;
+}


### PR DESCRIPTION
## Summary
Fixes a real orchestration gap discovered while investigating the multi-agent test thread: the platform tells every agent (via \`buildMultiAgentContext\` and default CLAUDE.md) to use MCP tools like \`delegate_to_agent\` and \`send_message\`, but the Ollama runtime adapter never passes a \`tools\` array to \`/api/chat\`. Those tools literally don't exist from an Ollama model's perspective, so the model does the only thing it can: narrate calling a tool it cannot invoke. That's the "I'll send this to agent two" pattern we saw repeatedly in test runs.

This PR ships Phase 1 + Phase 4a of #69.

## Phase 1 — \`src/model-capabilities.ts\`
Static capability matrix keyed on \`(provider, model)\`. Returns a \`CapabilityProfile\` with:
- \`receivesMcpTools\` — does the adapter actually pass tools to this runtime today
- \`streaming\` — shape of streamed content (per-token / chunked / whole)

Single source of truth. Future subsystems (#62 composer, #65 platform layer, UI badges) consult the same data.

Notes the nominal-vs-effective distinction in the module doc: Ollama's \`/api/show\` reports \`tools: true\` for many models, but \`receivesMcpTools\` is false because the adapter doesn't wire the plumbing. Phase 4b (#69) is where that plumbing lives.

## Phase 4a — branch context injection on the profile
### \`buildMultiAgentContext()\`
- **Tool-capable coordinator**: unchanged — full MCP delegation protocol, concrete \`delegate_to_agent\` example, sidebar status controls
- **Tool-less coordinator**: "your runtime does not have tool-calling access, cannot delegate programmatically — point the user at the specialist's trigger instead"
- **Tool-capable specialist**: unchanged
- **Tool-less specialist**: "respond in plain text, your entire reply is delivered as the user-visible message, no tools or status controls"

### \`POST /api/teams\` default CLAUDE.md generators
Same branch applied to auto-generated CLAUDE.md when the user leaves \`instructions\` blank in the team-create form. Ollama-runtime agents get the plain-text variant; Anthropic-runtime agents get the tool-based variant.

## Why binary instead of a full capability matrix yet
The binary \`receivesMcpTools\` flag closes the immediate bug — telling a tool-less agent about tools is misinformation regardless of which Ollama model it runs. The full matrix (parameter size, reliability tier, probed \`capabilities\` from \`/api/show\`) is Phase 2+ and doesn't need to land before this one is useful.

## How it was tested
- **10 unit tests** in \`src/model-capabilities.test.ts\` covering the matrix lookup + both \`buildMultiAgentContext\` branches (coordinator and specialist × tool-capable and tool-less)
- **Full test suite**: 463/463 passing
- **Live-verified end-to-end** via \`POST /api/teams\` with a mixed-runtime team:
  - Claude specialist CLAUDE.md unchanged from before (no regression)
  - Ollama specialist CLAUDE.md has zero \`mcp__nanoclaw__\` references, uses plain-text protocol
  - Claude coordinator CLAUDE.md contains the \`delegate_to_agent\` example
  - Ollama coordinator CLAUDE.md honestly says it cannot delegate

## Related
- #69 — capability governance umbrella issue (this PR lands Phase 1 + 4a)
- #65 — elevate platform-injected context as load-bearing reliability layer (same theme: platform owns protocol; this PR is a concrete step in that direction)
- #62 — revisit context layering architecture for multi-provider (capability matrix is the missing ingredient for the composition layer)
- #66 — team-create runtime pickers (this PR adds the runtime-aware CLAUDE.md defaults that #66's runtime selections now flow into)

## Out of scope / follow-ups
- Phase 2: merge probed Ollama \`/api/show\` capabilities into the profile
- Phase 3: UI badges at configure-time ("⚠ text-only" / "✓ tool-capable")
- Phase 4b: actually wire Ollama's \`tools\` parameter for capable models — turns the Ollama specialists into real tool-callers
- Phase 5: observability / adaptive degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)