### PR TITLE
Role-scoped tool allowlists for non-SDK runtimes (#74 Phase 1)

### DIFF
--- a/container/agent-runner/src/ollama-runtime.ts
+++ b/container/agent-runner/src/ollama-runtime.ts
@@ -320,7 +320,17 @@ export class OllamaRuntime {
     try {
       await bridge.connect();
       toolDescriptors = await bridge.listTools(input.constraints?.disallowedTools);
-      toolsForOllama = bridge.toProviderSpecs(toolDescriptors).map(specToOllamaTool);
+      // When the host passed an allowedTools list (role-scoped narrowing —
+      // see runtime-resolution.resolveTurnConstraints), filter to only
+      // those. Small tool-capable models hallucinate when given many
+      // simultaneous tools; narrow scopes stop that.
+      const allowSet = input.constraints?.allowedTools
+        ? new Set(input.constraints.allowedTools)
+        : null;
+      const narrowed = allowSet
+        ? toolDescriptors.filter((d) => allowSet.has(d.qualifiedName))
+        : toolDescriptors;
+      toolsForOllama = bridge.toProviderSpecs(narrowed).map(specToOllamaTool);
     } catch (err) {
       await bridge.close();
       yield {
@@ -333,7 +343,9 @@ export class OllamaRuntime {
     }
 
     log(
-      `Ollama: calling ${model} with ${seedMessages.length} messages, ${toolsForOllama.length} tools (tool-capable)`,
+      `Ollama: calling ${model} with ${seedMessages.length} messages, ${toolsForOllama.length} tools (tool-capable${
+        input.constraints?.allowedTools ? ', narrowed' : ''
+      })`,
     );
 
     const messages: Message[] = [...seedMessages];

--- a/container/agent-runner/src/runtime-interface.ts
+++ b/container/agent-runner/src/runtime-interface.ts
@@ -49,6 +49,8 @@ export interface RuntimeMessage {
 export interface RuntimeTurnConstraints {
   maxTurns?: number;
   disallowedTools?: string[];
+  /** Positive allowlist — when set, only these tools are exposed. */
+  allowedTools?: string[];
 }
 
 export interface RuntimeTurnInput {

--- a/src/runtime-resolution.test.ts
+++ b/src/runtime-resolution.test.ts
@@ -22,6 +22,7 @@ function makeGroup(
 function makeAgent(
   trigger: string | undefined,
   containerConfig?: Agent['containerConfig'],
+  runtime?: Agent['runtime'],
 ): Agent {
   return {
     id: 'test/agent',
@@ -30,6 +31,7 @@ function makeAgent(
     displayName: 'Agent',
     trigger,
     containerConfig,
+    runtime,
   };
 }
 
@@ -142,5 +144,51 @@ describe('resolveTurnConstraints', () => {
       'WebSearch',
       'mcp__nanoclaw__delegate_to_agent',
     ]);
+  });
+
+  // --- Role-scoped allowedTools (#74 Phase 1) ---
+
+  it('narrows Ollama tool-capable specialists to a minimal tool set', () => {
+    const result = resolveTurnConstraints(
+      makeAgent('@scout', undefined, {
+        provider: 'ollama',
+        model: 'qwen3.5:4b',
+      }),
+      makeGroup(),
+    );
+    expect(result?.allowedTools?.sort()).toEqual([
+      'mcp__nanoclaw__send_message',
+      'mcp__nanoclaw__set_agent_status',
+    ]);
+  });
+
+  it('does not narrow Ollama tool-less specialists (no tools anyway)', () => {
+    const result = resolveTurnConstraints(
+      makeAgent('@scout', undefined, {
+        provider: 'ollama',
+        model: 'llama3.2:1b',
+      }),
+      makeGroup(),
+    );
+    expect(result?.allowedTools).toBeUndefined();
+  });
+
+  it('does not narrow Claude specialists (SDK handles wide tool sets)', () => {
+    const result = resolveTurnConstraints(
+      makeAgent('@scout', undefined, { provider: 'anthropic' }),
+      makeGroup(),
+    );
+    expect(result?.allowedTools).toBeUndefined();
+  });
+
+  it('does not narrow Ollama coordinators — they need delegation tools', () => {
+    const result = resolveTurnConstraints(
+      makeAgent(undefined, undefined, {
+        provider: 'ollama',
+        model: 'qwen3.5:4b',
+      }),
+      makeGroup(),
+    );
+    expect(result?.allowedTools).toBeUndefined();
   });
 });

--- a/src/runtime-resolution.ts
+++ b/src/runtime-resolution.ts
@@ -3,10 +3,25 @@ import path from 'path';
 
 import { GROUPS_DIR } from './config.js';
 import { resolveGroupFolderPath } from './group-folder.js';
+import { getCapabilityProfile } from './model-capabilities.js';
 import { AgentRuntimeConfig, RuntimeTurnConstraints } from './runtime-types.js';
 import { Agent, ContainerConfig, RegisteredGroup } from './types.js';
 
 const SPECIALIST_AUTO_BLOCKED_TOOL = 'mcp__nanoclaw__delegate_to_agent';
+
+/**
+ * Minimal tool set for specialists on non-SDK runtimes (Ollama today).
+ * Small models hallucinate when given many simultaneous tools; narrowing
+ * to these two gives an unambiguous signal about what they can do.
+ *
+ * Keep in sync with #74's Phase 1 rationale. Claude specialists are not
+ * narrowed today — their SDK handles 18+ tools reliably and existing
+ * workflows depend on the wider set.
+ */
+const NON_SDK_SPECIALIST_ALLOWED_TOOLS = [
+  'mcp__nanoclaw__send_message',
+  'mcp__nanoclaw__set_agent_status',
+];
 
 export type PartialRuntimeConfig = Partial<AgentRuntimeConfig>;
 
@@ -143,14 +158,38 @@ export function resolveTurnConstraints(
   for (const tool of agentConfig?.disallowedTools ?? []) disallowed.add(tool);
 
   // Specialist = agent with a trigger (non-coordinator). Auto-block delegation.
-  if (agent?.trigger) {
+  const isSpecialist = Boolean(agent?.trigger);
+  if (isSpecialist) {
     disallowed.add(SPECIALIST_AUTO_BLOCKED_TOOL);
   }
 
-  if (maxTurns === undefined && disallowed.size === 0) return undefined;
+  // Role-scoped tool narrowing for non-SDK runtimes (Ollama today).
+  // Small tool-capable models get confused when handed 18 MCP tools at
+  // once — seen live with qwen3.5:4b hallucinating a tool name in #73.
+  // Narrowing specialists to just send_message + set_agent_status gives
+  // an unambiguous signal. Claude specialists are unchanged because the
+  // SDK handles wide tool sets reliably and existing workflows depend
+  // on them.
+  let allowedTools: string[] | undefined;
+  if (isSpecialist && agent) {
+    const profile = getCapabilityProfile(agent.runtime);
+    const isNonSdkRuntime = agent.runtime?.provider === 'ollama';
+    if (isNonSdkRuntime && profile.receivesMcpTools) {
+      allowedTools = [...NON_SDK_SPECIALIST_ALLOWED_TOOLS];
+    }
+  }
+
+  if (
+    maxTurns === undefined &&
+    disallowed.size === 0 &&
+    allowedTools === undefined
+  ) {
+    return undefined;
+  }
 
   return {
     ...(maxTurns !== undefined ? { maxTurns } : {}),
     ...(disallowed.size > 0 ? { disallowedTools: [...disallowed] } : {}),
+    ...(allowedTools !== undefined ? { allowedTools } : {}),
   };
 }

--- a/src/runtime-types.ts
+++ b/src/runtime-types.ts
@@ -61,6 +61,13 @@ export interface RuntimeTurnConstraints {
   // Tools the runtime must refuse to expose for this turn.
   // Exact names (e.g. "WebSearch") or MCP patterns (e.g. "mcp__nanoclaw__delegate_to_agent").
   disallowedTools?: string[];
+  // When set, only these tools are exposed — a positive allowlist that
+  // overrides the runtime's default tool set. Used for role-scoped
+  // narrowing (e.g. Ollama specialists get just
+  // mcp__nanoclaw__send_message + set_agent_status so small models
+  // don't hallucinate picking from 18 simultaneous options). Leave
+  // unset to use the runtime's default wide allowlist.
+  allowedTools?: string[];
 }
 
 export interface RuntimeTurnInput {


### PR DESCRIPTION
## Summary
Phase 1 of #74. Narrows Ollama tool-capable specialists to a minimal tool set (\`send_message\` + \`set_agent_status\`) so small models don't hallucinate picking from a wide schema.

**Ship-gate: closed.** Directly fixes the hallucination surfaced in #73.

| | Before (this PR) — 18 tools | After (this PR) — 2 tools |
|---|---|---|
| qwen3.5:4b invocation | hallucinated \`sdk_function_handler\` | real \`mcp__nanoclaw__send_message\` ✓ |
| Turn count | 2 (hallucinate → recover) | 2 (tool call → final) |
| Duration | 467s | 83s (**5.6× faster**) |
| Tokens | 408 | 65 |

## What changed

### Contract — \`RuntimeTurnConstraints.allowedTools?: string[]\`
Added on both sides (host \`src/runtime-types.ts\`, container \`runtime-interface.ts\`). Positive allowlist that overrides the runtime's default tool set when present. Leaving it unset preserves today's wide-allowlist behavior — no breaking changes.

### Host — \`resolveTurnConstraints\`
Sets \`allowedTools\` for specialists whose runtime is Ollama AND whose capability profile has \`receivesMcpTools: true\`. Claude specialists are deliberately left unchanged (SDK handles wide tool sets reliably; existing workflows depend on them). Coordinators of any provider also left unchanged (they need the full toolset including delegation).

### Ollama runtime — tool loop
Filters the bridge's \`listTools\` result by the allowlist before translating to Ollama's \`Tool[]\` shape. Logs \`(tool-capable, narrowed)\` so the mode is visible in container logs.

## Blast radius
- Ollama tool-capable specialists: **narrowed** (the change)
- Ollama tool-less specialists: no change (don't get tools anyway)
- Claude specialists: **no change** — SDK handles wide sets
- All coordinators: no change — need delegation tools
- Existing tests: green (466 → 470, +4 new tests)

## Testing

### Unit tests (4 new)
- Ollama tool-capable specialist gets the narrowed allowlist
- Ollama tool-less specialist gets no \`allowedTools\`
- Claude specialist gets no \`allowedTools\`
- Ollama coordinator gets no \`allowedTools\`

**Host: 470/470 passing. Container: 8/8 passing.**

### Live ship-gate
Created Claude-coord + qwen3.5:4b-specialist team, sent \`@qwen please say hi\`. Container log confirmed:
\`\`\`
Ollama: calling qwen3.5:4b with 2 messages, 2 tools (tool-capable, narrowed)
Ollama tool_call: mcp__nanoclaw__send_message
Ollama: qwen3.5:4b done — 65 tokens, 83.1s, 2 turn(s)
\`\`\`
Real tool invocation, real delivered message.

## Known follow-up (filed)
[#75](https://github.com/dfederspiel/clawdad/issues/75) — After calling \`send_message\`, the Ollama model sometimes produces a short redundant final-text turn (*"Hello! 👋"* alongside the full greeting). Creates a duplicate bubble. Deliberately not patched here with a simple suppress — hiding messages is a worse failure than duplicating one. Proper fix is root-cause: tag tools as \`delivers_user_content\` and make the loop terminal on those. Tracked separately.

## Related
- #74 — per-agent tool and skill selection (this is Phase 1; Phase 2 adds user-selectable tools; Phase 3 skills; Phase 4 profile editor)
- #73 — Ollama tool loop (the PR that surfaced the need)
- #75 — redundant final turn follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)