### PR TITLE
Per-profile delegation timeout (fixes #77)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ import { startSchedulerLoop } from './task-scheduler.js';
 import { Agent, Channel, NewMessage, RegisteredGroup } from './types.js';
 import type { MediaArtifact } from './types.js';
 import { logger } from './logger.js';
+import { getCapabilityProfile } from './model-capabilities.js';
 
 // Re-export for backwards compatibility during refactor
 export { escapeXml, formatMessages } from './router.js';
@@ -3000,7 +3001,12 @@ async function main(): Promise<void> {
       // delegations. The queue re-triggers the coordinator automatically
       // when all delegations for a group complete.
       const savedConfig = group.containerConfig;
-      const DELEGATION_TIMEOUT = 120_000; // 2 minutes
+      // Specialist's capability profile dictates how long the host will
+      // wait — fast cloud APIs (Claude) fail fast, slow local runtimes
+      // (CPU-only Ollama) get headroom. See src/model-capabilities.ts.
+      const delegationTimeout = getCapabilityProfile(
+        agent.runtime,
+      ).delegationTimeoutMs;
       const taskId = `delegation-${agent.name}-${Date.now()}`;
       queue.enqueueDelegation(
         chatJid,
@@ -3013,7 +3019,7 @@ async function main(): Promise<void> {
             ...savedConfig,
             timeout: Math.min(
               savedConfig?.timeout || Infinity,
-              DELEGATION_TIMEOUT,
+              delegationTimeout,
             ),
           };
           // Build prompt at execution time (not enqueue time) so conversation

--- a/src/model-capabilities.test.ts
+++ b/src/model-capabilities.test.ts
@@ -9,11 +9,13 @@ describe('getCapabilityProfile', () => {
     const p = getCapabilityProfile(undefined);
     expect(p.receivesMcpTools).toBe(true);
     expect(p.streaming).toBe('chunked');
+    expect(p.delegationTimeoutMs).toBe(120_000);
   });
 
   it('returns the anthropic profile for explicit anthropic', () => {
     const p = getCapabilityProfile({ provider: 'anthropic' });
     expect(p.receivesMcpTools).toBe(true);
+    expect(p.delegationTimeoutMs).toBe(120_000);
   });
 
   it('reports small ollama models as tool-less (not on the allowlist)', () => {
@@ -23,6 +25,7 @@ describe('getCapabilityProfile', () => {
     });
     expect(p.receivesMcpTools).toBe(false);
     expect(p.streaming).toBe('per-token');
+    expect(p.delegationTimeoutMs).toBe(300_000);
   });
 
   it('reports ollama qwen3.5:4b as tool-capable (on the allowlist)', () => {
@@ -31,16 +34,33 @@ describe('getCapabilityProfile', () => {
     // Tool loop runs non-streaming turns; the adapter delivers the final
     // assistant message whole.
     expect(p.streaming).toBe('whole');
+    expect(p.delegationTimeoutMs).toBe(600_000);
   });
 
   it('treats ollama with no model as tool-less (safe default)', () => {
     const p = getCapabilityProfile({ provider: 'ollama' });
     expect(p.receivesMcpTools).toBe(false);
+    expect(p.delegationTimeoutMs).toBe(300_000);
   });
 
   it('falls back to a tool-less profile for not-yet-wired providers', () => {
     const p = getCapabilityProfile({ provider: 'openai' });
     expect(p.receivesMcpTools).toBe(false);
+    expect(p.delegationTimeoutMs).toBe(120_000);
+  });
+
+  it('gives tool-capable Ollama more delegation headroom than text-only Ollama', () => {
+    const toolCapable = getCapabilityProfile({
+      provider: 'ollama',
+      model: 'qwen3.5:4b',
+    });
+    const textOnly = getCapabilityProfile({
+      provider: 'ollama',
+      model: 'llama3.2:1b',
+    });
+    expect(toolCapable.delegationTimeoutMs).toBeGreaterThan(
+      textOnly.delegationTimeoutMs,
+    );
   });
 });
 

--- a/src/model-capabilities.ts
+++ b/src/model-capabilities.ts
@@ -34,11 +34,22 @@ export interface CapabilityProfile {
    * only a final full message, no streaming.
    */
   streaming: 'per-token' | 'chunked' | 'whole';
+
+  /**
+   * Max time the host waits for a delegated turn to complete before
+   * cancelling and surfacing a "specialist was unable to complete" error.
+   * Picked off the **specialist's** profile at delegation time: fast
+   * cloud APIs (Claude) fail fast so a wedged container doesn't stall
+   * the group; slow local models (CPU-only Ollama) get headroom for
+   * real tool-loop work (observed 83s–467s on qwen3.5:4b, macOS CPU).
+   */
+  delegationTimeoutMs: number;
 }
 
 const ANTHROPIC_PROFILE: CapabilityProfile = {
   receivesMcpTools: true,
   streaming: 'chunked',
+  delegationTimeoutMs: 120_000, // 2 min — fast cloud API, fail fast on hangs
 };
 
 // Ollama models for which the container adapter wires tools end-to-end.
@@ -54,6 +65,7 @@ const TOOL_CAPABLE_OLLAMA_MODELS = new Set<string>(['qwen3.5:4b']);
 const OLLAMA_TEXT_ONLY_PROFILE: CapabilityProfile = {
   receivesMcpTools: false,
   streaming: 'per-token',
+  delegationTimeoutMs: 300_000, // 5 min — CPU-only text generation, no tool loop
 };
 
 const OLLAMA_TOOL_CAPABLE_PROFILE: CapabilityProfile = {
@@ -61,6 +73,7 @@ const OLLAMA_TOOL_CAPABLE_PROFILE: CapabilityProfile = {
   // Tool loop runs non-streaming turns (we need the full response to read
   // tool_calls); the final assistant message is delivered whole.
   streaming: 'whole',
+  delegationTimeoutMs: 600_000, // 10 min — headroom for CPU-only tool loops
 };
 
 // Safe default for providers we haven't wired yet. Assume text-only so
@@ -68,6 +81,7 @@ const OLLAMA_TOOL_CAPABLE_PROFILE: CapabilityProfile = {
 const UNSUPPORTED_PROFILE: CapabilityProfile = {
   receivesMcpTools: false,
   streaming: 'whole',
+  delegationTimeoutMs: 120_000, // 2 min — conservative default until wired
 };
 
 /**


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Closes #77.

**What** — Moves `DELEGATION_TIMEOUT` off a hardcoded 2-minute constant and onto the capability profile in [src/model-capabilities.ts](src/model-capabilities.ts), so the cap can vary by runtime.

**Why** — The 2-minute cap is safe for Claude over the SDK (delegations complete in seconds) but too short for CPU-only Ollama specialists doing real tool-loop work. Observed durations on macOS CPU:

| Scenario | Turns | Duration |
|---|---|---|
| `qwen3.5:4b` with 18 tools (#73) | 2 | ~467s |
| `qwen3.5:4b` narrowed to 2 tools (#76) | 2 | ~83s |
| Isolated single-tool invocation | 1 | ~320s |

All of these exceed the 2-minute cap, producing spurious "Specialist was unable to complete" errors even when the tool loop would have succeeded.

**How it works** — `CapabilityProfile` gains a required `delegationTimeoutMs` field, populated per profile:

- Anthropic: 2 min (unchanged — fast cloud, fail fast on hangs)
- Ollama text-only: 5 min
- Ollama tool-capable: 10 min
- Unsupported: 2 min (conservative default)

[src/index.ts](src/index.ts) now reads `getCapabilityProfile(agent.runtime).delegationTimeoutMs` — the **specialist's** profile, since the coordinator dispatches fast and its profile doesn't matter.

**How it was tested** — `npm run build` clean; all 471 vitest tests pass, including 6 new assertions in [src/model-capabilities.test.ts](src/model-capabilities.test.ts) and one invariant test (tool-capable Ollama gets strictly more headroom than text-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)