### PR TITLE
Per-agent tool selection via agent.json (Phase 2a of #74)

### DIFF
--- a/container/agent-runner/src/claude-runtime.ts
+++ b/container/agent-runner/src/claude-runtime.ts
@@ -394,7 +394,32 @@ export class ClaudeCodeRuntime implements RuntimeSession {
       process.env.CLAUDE_MODEL ||
       undefined;
 
-    const { maxTurns, disallowedTools } = input.constraints ?? {};
+    const { maxTurns, disallowedTools, allowedTools } = input.constraints ?? {};
+    // Explicit per-agent allowlist (Phase 2 of #74) overrides the built-in
+    // default — lets power users narrow Claude agents the same way Phase 1
+    // already narrows Ollama specialists.
+    const claudeAllowedTools = allowedTools ?? [
+      'Bash',
+      'Read',
+      'Write',
+      'Edit',
+      'Glob',
+      'Grep',
+      'WebSearch',
+      'WebFetch',
+      'Task',
+      'TaskOutput',
+      'TaskStop',
+      'TeamCreate',
+      'TeamDelete',
+      'SendMessage',
+      'TodoWrite',
+      'ToolSearch',
+      'Skill',
+      'NotebookEdit',
+      'mcp__nanoclaw__*',
+      'mcp__ollama__*',
+    ];
 
     for await (const message of query({
       prompt: stream,
@@ -420,28 +445,7 @@ export class ClaudeCodeRuntime implements RuntimeSession {
               }
             : undefined;
         })(),
-        allowedTools: [
-          'Bash',
-          'Read',
-          'Write',
-          'Edit',
-          'Glob',
-          'Grep',
-          'WebSearch',
-          'WebFetch',
-          'Task',
-          'TaskOutput',
-          'TaskStop',
-          'TeamCreate',
-          'TeamDelete',
-          'SendMessage',
-          'TodoWrite',
-          'ToolSearch',
-          'Skill',
-          'NotebookEdit',
-          'mcp__nanoclaw__*',
-          'mcp__ollama__*',
-        ],
+        allowedTools: claudeAllowedTools,
         env: this.options.sdkEnv,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -110,6 +110,11 @@ function loadAgentFromDir(
       if (config.containerConfig)
         agent.containerConfig = config.containerConfig as ContainerConfig;
       if (config.runtime) agent.runtime = config.runtime as AgentRuntimeConfig;
+      if (Array.isArray(config.tools)) {
+        agent.tools = config.tools.filter(
+          (t: unknown): t is string => typeof t === 'string',
+        );
+      }
     } catch (err) {
       logger.warn(
         { group: groupFolder, agent: agentName, err },

--- a/src/runtime-resolution.test.ts
+++ b/src/runtime-resolution.test.ts
@@ -23,6 +23,7 @@ function makeAgent(
   trigger: string | undefined,
   containerConfig?: Agent['containerConfig'],
   runtime?: Agent['runtime'],
+  tools?: Agent['tools'],
 ): Agent {
   return {
     id: 'test/agent',
@@ -32,6 +33,7 @@ function makeAgent(
     trigger,
     containerConfig,
     runtime,
+    tools,
   };
 }
 
@@ -190,5 +192,55 @@ describe('resolveTurnConstraints', () => {
       makeGroup(),
     );
     expect(result?.allowedTools).toBeUndefined();
+  });
+
+  // --- Per-agent tools override (#74 Phase 2) ---
+
+  it('honours an explicit agent.tools override on a Claude specialist', () => {
+    const result = resolveTurnConstraints(
+      makeAgent('@researcher', undefined, { provider: 'anthropic' }, [
+        'WebSearch',
+        'WebFetch',
+        'mcp__nanoclaw__send_message',
+      ]),
+      makeGroup(),
+    );
+    expect(result?.allowedTools).toEqual([
+      'WebSearch',
+      'WebFetch',
+      'mcp__nanoclaw__send_message',
+    ]);
+  });
+
+  it('honours an explicit agent.tools override on a coordinator', () => {
+    const result = resolveTurnConstraints(
+      makeAgent(undefined, undefined, { provider: 'anthropic' }, ['WebSearch']),
+      makeGroup(),
+    );
+    expect(result?.allowedTools).toEqual(['WebSearch']);
+  });
+
+  it('explicit agent.tools overrides the Ollama role default (widens it)', () => {
+    const result = resolveTurnConstraints(
+      makeAgent(
+        '@scout',
+        undefined,
+        { provider: 'ollama', model: 'qwen3.5:4b' },
+        ['mcp__nanoclaw__send_message', 'WebSearch'],
+      ),
+      makeGroup(),
+    );
+    expect(result?.allowedTools).toEqual([
+      'mcp__nanoclaw__send_message',
+      'WebSearch',
+    ]);
+  });
+
+  it('honours an empty agent.tools array as an explicit "no tools" opt-out', () => {
+    const result = resolveTurnConstraints(
+      makeAgent('@quiet', undefined, { provider: 'anthropic' }, []),
+      makeGroup(),
+    );
+    expect(result?.allowedTools).toEqual([]);
   });
 });

--- a/src/runtime-resolution.ts
+++ b/src/runtime-resolution.ts
@@ -163,15 +163,22 @@ export function resolveTurnConstraints(
     disallowed.add(SPECIALIST_AUTO_BLOCKED_TOOL);
   }
 
-  // Role-scoped tool narrowing for non-SDK runtimes (Ollama today).
-  // Small tool-capable models get confused when handed 18 MCP tools at
-  // once — seen live with qwen3.5:4b hallucinating a tool name in #73.
-  // Narrowing specialists to just send_message + set_agent_status gives
-  // an unambiguous signal. Claude specialists are unchanged because the
-  // SDK handles wide tool sets reliably and existing workflows depend
-  // on them.
+  // Allowlist precedence: explicit `agent.tools` (Phase 2 of #74) > role
+  // default (Phase 1) > runtime's built-in default (no constraint).
+  //
+  // Role-scoped narrowing for non-SDK runtimes (Ollama today): small
+  // tool-capable models get confused when handed 18 MCP tools at once —
+  // seen live with qwen3.5:4b hallucinating a tool name in #73. Narrowing
+  // specialists to just send_message + set_agent_status gives an
+  // unambiguous signal. Claude specialists are unchanged at the role
+  // layer because the SDK handles wide tool sets reliably and existing
+  // workflows depend on them — but they can still be narrowed explicitly
+  // via `agent.tools`.
   let allowedTools: string[] | undefined;
-  if (isSpecialist && agent) {
+  if (agent?.tools !== undefined) {
+    // Explicit override — honour exactly, including empty array ("no tools").
+    allowedTools = [...agent.tools];
+  } else if (isSpecialist && agent) {
     const profile = getCapabilityProfile(agent.runtime);
     const isNonSdkRuntime = agent.runtime?.provider === 'ollama';
     if (isNonSdkRuntime && profile.receivesMcpTools) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,11 @@ export interface Agent {
   status?: string; // Agent-settable status line shown under the agent row
   containerConfig?: ContainerConfig; // Agent-specific overrides
   runtime?: AgentRuntimeConfig; // Provider/model execution boundary
+  // Positive tool allowlist that overrides both the role-based default
+  // (Phase 1 of #74) and the runtime's built-in default. Supports SDK
+  // wildcards on Claude (e.g. `mcp__nanoclaw__*`); Ollama matches exact
+  // names only. An empty array means "no tools" — an explicit opt-out.
+  tools?: string[];
 }
 
 export type WorkPhase =


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Partial work on #74. Phase 1 (PR #76) shipped role-scoped defaults; this is the config-plumbing half of Phase 2. No UI yet.

**What** — `agent.json` gains an optional `tools: string[]` field. When set, it overrides both the Phase 1 role default and the runtime's built-in default.

```json
{
  "displayName": "Researcher",
  "trigger": "@researcher",
  "tools": ["WebSearch", "WebFetch", "mcp__nanoclaw__send_message"]
}
```

**Why** — Phase 1 closed the Ollama-specialist hallucination loop from #73 by hardcoding a minimal allowlist for that role. But users who want to shape agents differently (e.g. a Claude "Researcher" with just web tools, or an Ollama specialist that _also_ needs `WebSearch`) had no way to express that without editing source. This is that knob.

**How it works** — Precedence: `agent.tools` (explicit) > role default (Phase 1) > runtime's built-in default.

- [src/types.ts](src/types.ts) — `Agent.tools?: string[]`
- [src/agent-discovery.ts](src/agent-discovery.ts) — parses and validates the field (string array only)
- [src/runtime-resolution.ts](src/runtime-resolution.ts) — `resolveTurnConstraints` checks `agent.tools` first; empty array means "no tools" (explicit opt-out)
- [container/agent-runner/src/claude-runtime.ts](container/agent-runner/src/claude-runtime.ts) — the Claude adapter now respects `constraints.allowedTools` instead of hardcoding a 20-item list. The same list remains the default when no override is set. (Ollama already respected this from Phase 1.)

**How it was tested** — `npm run build` clean (host + container-runner); all 475 vitest tests pass, including 4 new assertions in [src/runtime-resolution.test.ts](src/runtime-resolution.test.ts):

- Explicit override on a Claude specialist
- Explicit override on a coordinator (normally no allowlist)
- Explicit override widens the Ollama specialist narrow-default
- Empty array honoured as "no tools"

**What's not in this PR (Phase 2b)** — the UI checklist and `GET /api/tools` registry endpoint. Those become additive work once the config contract is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)