### PR TITLE
Pass structured messages to container, drop XML reverse-engineering (closes #46)

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -23,8 +23,19 @@ import { AgentRuntimeConfig, RuntimeTurnConstraints } from './runtime-interface.
 import { ClaudeCodeRuntime } from './claude-runtime.js';
 import { OllamaRuntime } from './ollama-runtime.js';
 
+interface StructuredMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  sender?: string;
+  timestamp?: string;
+}
+
 interface ContainerInput {
   prompt: string;
+  // Structured conversation history (#46). Runtimes that can consume real
+  // message boundaries (Ollama) read this directly; Claude keeps using the
+  // XML-formatted `prompt` for SDK compatibility.
+  messages?: StructuredMessage[];
   sessionId?: string;
   groupFolder: string;
   chatJid: string;
@@ -460,8 +471,23 @@ async function runQuery(
           ipcPollMs: IPC_POLL_MS,
         });
 
+  // Claude keeps the legacy XML-in-a-single-user-message shape — the SDK
+  // owns its own conversation state via session-resume, and the XML gives
+  // the model sender/timestamp framing it already expects. Any other
+  // runtime gets the structured messages when the host populated them
+  // (#46), since reconstructing roles from XML was fragile and lossy.
+  const providerIsClaude =
+    (containerInput.runtime?.provider || 'anthropic') === 'anthropic';
+  const runtimeMessages =
+    !providerIsClaude && containerInput.messages && containerInput.messages.length > 0
+      ? containerInput.messages.map((m) => ({
+          role: m.role,
+          content: [{ type: 'text' as const, text: m.content }],
+        }))
+      : [{ role: 'user' as const, content: [{ type: 'text' as const, text: prompt }] }];
+
   for await (const event of runtime.runTurn({
-    messages: [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
+    messages: runtimeMessages,
     attachments: [],
     threadId: undefined,
     agentId: containerInput.agentId || containerInput.agentName || 'default',

--- a/container/agent-runner/src/ollama-runtime.ts
+++ b/container/agent-runner/src/ollama-runtime.ts
@@ -66,39 +66,6 @@ export async function ollamaModelSupportsTools(model: string): Promise<boolean> 
 
 const MAX_TOOL_TURNS = 10;
 
-/**
- * Parse the XML-formatted conversation history produced by the host's
- * formatMessages() into individual Ollama chat messages. Bot messages
- * become assistant role, everything else becomes user role.
- *
- * Tracked for removal in #46 — host should pass structured messages so
- * this reverse-engineering step goes away.
- */
-function parseXmlMessages(text: string, assistantName?: string): Message[] {
-  const msgRegex =
-    /<message\s+sender="([^"]*)"\s+time="[^"]*">([^<]*(?:<(?!\/message>)[^<]*)*)<\/message>/g;
-  const results: Message[] = [];
-  let match;
-  while ((match = msgRegex.exec(text)) !== null) {
-    const sender = match[1];
-    const content = match[2]
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .trim();
-    if (!content) continue;
-    const isBot =
-      (assistantName && sender === assistantName) ||
-      /^(Andy|Assistant|Bot)$/i.test(sender);
-    results.push({
-      role: isBot ? 'assistant' : 'user',
-      content,
-    });
-  }
-  return results;
-}
-
 interface ContainerInputLike {
   chatJid: string;
   groupFolder: string;
@@ -210,8 +177,9 @@ export class OllamaRuntime {
   }
 
   /**
-   * Build the system prompt + user/assistant history, parsing XML as
-   * needed. Shared between text-only and tool-capable paths.
+   * Build the system prompt + user/assistant history from the structured
+   * messages the host passes in ContainerInput (see #46). Shared between
+   * text-only and tool-capable paths.
    */
   private async buildBaseMessages(
     input: RuntimeTurnInput,
@@ -233,19 +201,18 @@ export class OllamaRuntime {
       messages.push({ role: 'system', content: systemParts.join('\n\n') });
     }
 
+    // Structured path (#46): the host now populates containerInput.messages
+    // and the container-runner hands them to us as pre-structured
+    // RuntimeMessages. Pass role + joined text through verbatim — no more
+    // reverse-engineering XML to guess who said what.
     for (const msg of input.messages) {
-      const textParts = msg.content
+      const text = msg.content
         .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-        .map((p) => p.text);
-      const fullText = textParts.join('\n');
-      const xmlMessages = parseXmlMessages(
-        fullText,
-        this.options.containerInput.assistantName,
-      );
-      if (xmlMessages.length > 0) {
-        for (const xm of xmlMessages) messages.push(xm);
-      } else if (fullText.trim()) {
-        messages.push({ role: msg.role, content: fullText });
+        .map((p) => p.text)
+        .join('\n')
+        .trim();
+      if (text) {
+        messages.push({ role: msg.role, content: text });
       }
     }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -37,6 +37,7 @@ import { validateAdditionalMounts } from './mount-security.js';
 import { readEnvFile } from './env.js';
 import { RegisteredGroup } from './types.js';
 import { AgentRuntimeConfig, RuntimeTurnConstraints } from './runtime-types.js';
+import type { StructuredMessage } from './router.js';
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
@@ -54,6 +55,11 @@ export interface ProgressEvent {
 
 export interface ContainerInput {
   prompt: string;
+  // Structured conversation history in (role, content) form. Runtimes
+  // that need real message boundaries (Ollama) read this directly;
+  // Claude continues using the XML-formatted `prompt` for backward
+  // compatibility with the SDK. See #46.
+  messages?: StructuredMessage[];
   sessionId?: string;
   groupFolder: string;
   chatJid: string;

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -10,6 +10,7 @@ import {
   formatMessages,
   formatOutbound,
   stripInternalTags,
+  toStructuredMessages,
 } from './router.js';
 import { parseTextStyles, parseSignalStyles } from './text-styles.js';
 import { NewMessage } from './types.js';
@@ -547,5 +548,84 @@ describe('formatOutbound — channel-aware', () => {
 
   it('signal channel is passthrough — raw markdown preserved for parseSignalStyles', () => {
     expect(formatOutbound('**bold**', 'signal')).toBe('**bold**');
+  });
+});
+
+// --- toStructuredMessages (#46) ---
+
+describe('toStructuredMessages', () => {
+  it('returns an empty array for no messages', () => {
+    expect(toStructuredMessages([])).toEqual([]);
+  });
+
+  it('maps is_bot_message: true to role="assistant"', () => {
+    const out = toStructuredMessages([
+      makeMsg({ is_bot_message: true, sender_name: 'Andy', content: 'hi' }),
+    ]);
+    expect(out).toEqual([
+      {
+        role: 'assistant',
+        content: 'hi',
+        sender: 'Andy',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('maps is_bot_message: false (and missing) to role="user"', () => {
+    const out = toStructuredMessages([
+      makeMsg({
+        sender_name: 'Alice',
+        content: 'hello',
+        is_bot_message: false,
+      }),
+      makeMsg({ sender_name: 'Bob', content: 'hey' }), // is_bot_message omitted
+    ]);
+    expect(out.map((m) => m.role)).toEqual(['user', 'user']);
+  });
+
+  it('preserves role authority via is_bot_message regardless of sender_name', () => {
+    // A human user named "Assistant" should still be role: user —
+    // this proves we no longer rely on the fragile name-match heuristic
+    // that the old parseXmlMessages used.
+    const out = toStructuredMessages([
+      makeMsg({
+        sender_name: 'Assistant',
+        content: 'typed by a real user',
+        is_bot_message: false,
+      }),
+    ]);
+    expect(out[0].role).toBe('user');
+  });
+
+  it('carries content, sender, and timestamp through unchanged', () => {
+    const out = toStructuredMessages([
+      makeMsg({
+        sender_name: 'Alice',
+        content: 'Look at <this> & "that"',
+        timestamp: '2026-04-19T03:00:00.000Z',
+      }),
+    ]);
+    expect(out[0]).toEqual({
+      role: 'user',
+      content: 'Look at <this> & "that"',
+      sender: 'Alice',
+      timestamp: '2026-04-19T03:00:00.000Z',
+    });
+  });
+
+  it('preserves order', () => {
+    const out = toStructuredMessages([
+      makeMsg({ id: '1', sender_name: 'A', content: 'first' }),
+      makeMsg({
+        id: '2',
+        sender_name: 'Andy',
+        content: 'second',
+        is_bot_message: true,
+      }),
+      makeMsg({ id: '3', sender_name: 'A', content: 'third' }),
+    ]);
+    expect(out.map((m) => m.content)).toEqual(['first', 'second', 'third']);
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,9 @@ import {
   formatMessages,
   formatOutbound,
   stripInternalTags,
+  toStructuredMessages,
 } from './router.js';
+import type { StructuredMessage } from './router.js';
 import { ChannelType } from './text-styles.js';
 import {
   restoreRemoteControl,
@@ -746,6 +748,17 @@ async function executeAutomationActions(
                 ? `\n\n--- Auto-routed by rule "${trace.ruleId}" ---\n${action.messageTemplate}\n`
                 : `\n\n--- Auto-routed by rule "${trace.ruleId}" ---\n`;
               const delegationPrompt = conversationCtx + routingNote;
+              const routedMessages: StructuredMessage[] = [
+                ...toStructuredMessages(recentMessages),
+                {
+                  role: 'user',
+                  content: action.messageTemplate
+                    ? `Auto-routed by rule "${trace.ruleId}": ${action.messageTemplate}`
+                    : `Auto-routed by rule "${trace.ruleId}"`,
+                  sender: 'system',
+                  timestamp: new Date().toISOString(),
+                },
+              ];
 
               setActiveAgentName(chatJid, agent.displayName);
               await channel.setTyping?.(chatJid, true);
@@ -824,6 +837,7 @@ async function executeAutomationActions(
                 },
                 batchId,
                 multiAgentCtx || undefined,
+                routedMessages,
               );
 
               group.containerConfig = savedConfig;
@@ -1100,6 +1114,7 @@ async function processGroupMessages(
   // For triggered agents, prepend conversation context from the origin chat
   // so the agent understands what's being discussed.
   let prompt: string;
+  let structuredMessages: StructuredMessage[];
   if (originJid && group.triggerScope === 'web-all') {
     const originContext = getMessagesSince(
       originJid,
@@ -1119,8 +1134,13 @@ async function processGroupMessages(
         formatMessages(contextOnly, TIMEZONE) +
         '\n--- Your trigger message ---\n' +
         formatMessages(missedMessages, TIMEZONE);
+      structuredMessages = [
+        ...toStructuredMessages(contextOnly),
+        ...toStructuredMessages(missedMessages),
+      ];
     } else {
       prompt = formatMessages(missedMessages, TIMEZONE);
+      structuredMessages = toStructuredMessages(missedMessages);
     }
     logger.info(
       {
@@ -1133,6 +1153,7 @@ async function processGroupMessages(
     );
   } else {
     prompt = formatMessages(missedMessages, TIMEZONE);
+    structuredMessages = toStructuredMessages(missedMessages);
   }
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
@@ -1300,6 +1321,7 @@ async function processGroupMessages(
               },
               batchId,
               multiAgentCtx || undefined,
+              structuredMessages,
             );
 
             group.containerConfig = savedConfig;
@@ -1577,6 +1599,7 @@ async function processGroupMessages(
       },
       batchId,
       multiAgentCtx || undefined,
+      structuredMessages,
     );
 
     await responseChannel.setTyping?.(
@@ -1645,6 +1668,7 @@ async function runAgent(
   sendMessage?: (text: string) => Promise<void>,
   runBatchId?: string,
   systemContext?: string,
+  messages?: StructuredMessage[],
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
   const agentId = agent?.id || `${group.folder}/${DEFAULT_AGENT_NAME}`;
@@ -2013,6 +2037,7 @@ async function runAgent(
 
       const containerInput = {
         prompt,
+        messages,
         sessionId,
         groupFolder: group.folder,
         chatJid,
@@ -2089,6 +2114,7 @@ async function runAgent(
     // ── Non-pool path: delegations, tasks, or pool disabled ─────
     const containerInput = {
       prompt,
+      messages,
       sessionId,
       groupFolder: group.folder,
       chatJid,
@@ -3047,6 +3073,19 @@ async function main(): Promise<void> {
           const delegationPrompt =
             conversationCtx +
             `\n\n--- Delegation from ${sourceAgent} ---\n${message}\n--- End delegation ---\n`;
+          // For non-Claude runtimes the delegation instruction was silently
+          // dropped by the XML parser (it lives outside <messages>). Inject
+          // it as a synthetic final user message so it actually reaches the
+          // model via the structured path.
+          const delegationMessages: StructuredMessage[] = [
+            ...toStructuredMessages(recentMessages),
+            {
+              role: 'user',
+              content: `Delegation from ${sourceAgent}: ${message}`,
+              sender: sourceAgent,
+              timestamp: new Date().toISOString(),
+            },
+          ];
 
           setActiveAgentName(chatJid, agent.displayName);
           await channel.setTyping?.(chatJid, true);
@@ -3123,6 +3162,7 @@ async function main(): Promise<void> {
             },
             batchId,
             multiAgentCtx || undefined,
+            delegationMessages,
           );
 
           group.containerConfig = savedConfig; // restore original config

--- a/src/ollama-capabilities.test.ts
+++ b/src/ollama-capabilities.test.ts
@@ -24,7 +24,7 @@ function mockFetch(
   ) => { status: number; body: unknown },
 ): void {
   globalThis.fetch = vi.fn(
-    async (url: RequestInfo | URL, init?: RequestInit) => {
+    async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
       const { status, body } = handler(String(url), init);
       return new Response(JSON.stringify(body), { status });
     },

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,6 +11,33 @@ export function escapeXml(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
+/**
+ * Structured form of a conversation message — passed to runtime adapters
+ * alongside the legacy XML prompt (#46). Gives non-Claude runtimes a
+ * direct (role, content) feed instead of reverse-engineering XML.
+ *
+ * Role is authoritative from `NewMessage.is_bot_message`, not heuristic
+ * name matching. Sender and timestamp are carried for display/debug use
+ * but aren't required by any current runtime.
+ */
+export interface StructuredMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  sender: string;
+  timestamp: string;
+}
+
+export function toStructuredMessages(
+  messages: NewMessage[],
+): StructuredMessage[] {
+  return messages.map((m) => ({
+    role: m.is_bot_message ? 'assistant' : 'user',
+    content: m.content,
+    sender: m.sender_name,
+    timestamp: m.timestamp,
+  }));
+}
+
 export function formatMessages(
   messages: NewMessage[],
   timezone: string,


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Closes #46. Eliminates the parseXmlMessages reverse-engineering hack in the Ollama runtime and fixes a latent delegation bug as a side effect.

**What was wrong**

The host formatted conversation history as Claude-flavoured XML and stuffed it into a single \`ContainerInput.prompt\` string. Non-Claude runtimes had to reverse-engineer it via regex parsing in [\`parseXmlMessages\`](container/agent-runner/src/ollama-runtime.ts) — guessing user/assistant roles from a sender-name heuristic (\`Andy\`, \`Assistant\`, \`Bot\`) because the authoritative \`is_bot_message\` flag never made it through the XML layer.

Two problems fell out of that:

1. **Role detection was fragile.** A real user named \`Assistant\` would be misclassified as the bot.
2. **Anything outside \`<message>\` tags was silently dropped.** The delegation instruction (\`--- Delegation from X ---\\n{body}\`) lives AFTER \`</messages>\` in the prompt — Claude saw it via the SDK, but Ollama specialists never did. Specialists were being asked \"please handle this\" and only hearing prior conversation history. **Latent bug, fixed as a side effect.**

**What this PR does**

- [\`src/router.ts\`](src/router.ts) — adds \`StructuredMessage\` type + \`toStructuredMessages\` helper. Role authoritatively derived from \`is_bot_message\`, no name matching.
- [\`src/container-runner.ts\`](src/container-runner.ts) — \`ContainerInput\` gains optional \`messages: StructuredMessage[]\`. Coexists with \`prompt\`.
- [\`src/index.ts\`](src/index.ts) — each \`runAgent\` call site now builds messages alongside the XML prompt. **Delegation and auto-routed cases append a synthetic user message** so the routing instruction actually reaches non-Claude runtimes.
- [\`container/agent-runner/src/index.ts\`](container/agent-runner/src/index.ts) — when the runtime is anything other than Claude AND structured messages are present, hand them to \`runTurn\` directly. **Claude path keeps the legacy single-XML-message shape unchanged** — the SDK manages its own session and the XML framing is what the model expects.
- [\`container/agent-runner/src/ollama-runtime.ts\`](container/agent-runner/src/ollama-runtime.ts) — \`parseXmlMessages\` deleted (~30 lines of regex + heuristics). \`buildBaseMessages\` now iterates \`input.messages\` directly.

**Drive-by build fix**

[\`src/ollama-capabilities.test.ts\`](src/ollama-capabilities.test.ts) had a TS2552 error on \`RequestInfo\` (DOM type not in this tsconfig's lib). Replaced with \`Parameters<typeof fetch>[0]\` so the build is green again. (Was failing on \`main\` post-#80; caught by my pre-commit build.)

**How it was tested**

- \`npm run build\` clean (host + container)
- \`npx vitest run\` — 488 passing (6 new in [\`src/formatting.test.ts\`](src/formatting.test.ts) covering \`toStructuredMessages\` role mapping, including the explicit case proving a user named \"Assistant\" still gets \`role: user\`)
- End-to-end with rebuilt container:
  - Claude coordinator: replied \"Hi!\" — legacy XML path byte-identical
  - Ollama qwen3.5:4b specialist: received delegation as a structured message, invoked \`send_message\`, delivered a real reply (\"Hello! Three here 👋\"). Previously this delegation instruction would have been silently dropped.

**What's not in this PR**

The session-commands resume path (\`src/session-commands.ts\`) and the IPC piping path (\`src/index.ts:formatMessages → queue.sendMessage\`) still use the XML prompt. Both are Claude-only flows (SDK session resume, mid-query message piping) that have no Ollama analogue. Leaving them as XML keeps the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)