### PR TITLE
Notification bell with activity history (closes #64)

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -98,3 +98,13 @@ dialog::backdrop { background: rgba(0, 0, 0, 0.6); }
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
+
+/* Brief highlight when navigating to a message from the notification bell */
+@keyframes notif-flash {
+  0%   { background-color: var(--accent-dim); box-shadow: 0 0 0 2px var(--accent); }
+  100% { background-color: transparent; box-shadow: 0 0 0 0 transparent; }
+}
+.notif-flash {
+  animation: notif-flash 1.6s ease-out;
+  border-radius: 8px;
+}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -51,6 +51,95 @@ export const dismissedPressure = signal({}); // { [jid]: true } — user dismiss
 // time without refetching /api/groups on every message.
 export const lastActivityOverride = signal({});
 
+// --- Notifications ---
+const NOTIF_HISTORY_KEY = 'clawdad-notifications-history';
+const NOTIF_LAST_READ_KEY = 'clawdad-notifications-last-read';
+const NOTIF_MAX = 50;
+const NOTIF_PREVIEW_LEN = 120;
+
+function loadNotifHistory() {
+  try {
+    const raw = localStorage.getItem(NOTIF_HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.slice(0, NOTIF_MAX) : [];
+  } catch { return []; }
+}
+
+function loadNotifLastRead() {
+  try {
+    const raw = localStorage.getItem(NOTIF_LAST_READ_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch { return {}; }
+}
+
+export const notifications = signal(loadNotifHistory());
+export const notifLastReadAt = signal(loadNotifLastRead());
+export const flashMessageId = signal(null);
+export const unreadNotifCount = computed(() => {
+  const lastRead = notifLastReadAt.value;
+  return notifications.value.filter(
+    (n) => !lastRead[n.jid] || n.timestamp > lastRead[n.jid],
+  ).length;
+});
+
+function persistNotifications() {
+  try {
+    localStorage.setItem(NOTIF_HISTORY_KEY, JSON.stringify(notifications.value));
+  } catch { /* quota / private mode */ }
+}
+
+function persistNotifLastRead() {
+  try {
+    localStorage.setItem(NOTIF_LAST_READ_KEY, JSON.stringify(notifLastReadAt.value));
+  } catch { /* ignore */ }
+}
+
+function truncatePreview(text) {
+  if (!text) return '';
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  return collapsed.length > NOTIF_PREVIEW_LEN
+    ? collapsed.slice(0, NOTIF_PREVIEW_LEN) + '…'
+    : collapsed;
+}
+
+function pushNotification(entry) {
+  if (!entry.id || !entry.jid) return;
+  const existing = notifications.value;
+  if (existing.some((n) => n.id === entry.id)) return;
+  const next = [entry, ...existing].slice(0, NOTIF_MAX);
+  notifications.value = next;
+  persistNotifications();
+}
+
+export function markGroupNotificationsRead(jid) {
+  if (!jid) return;
+  notifLastReadAt.value = { ...notifLastReadAt.value, [jid]: new Date().toISOString() };
+  persistNotifLastRead();
+}
+
+export function markAllNotificationsRead() {
+  const now = new Date().toISOString();
+  const next = { ...notifLastReadAt.value };
+  for (const n of notifications.value) next[n.jid] = now;
+  notifLastReadAt.value = next;
+  persistNotifLastRead();
+}
+
+export async function navigateToMessage(jid, messageId) {
+  if (!jid) return;
+  if (selectedJid.value !== jid) await selectGroup(jid);
+  if (!messageId) return;
+  flashMessageId.value = messageId;
+  requestAnimationFrame(() => {
+    const el = document.getElementById(`msg-${messageId}`);
+    if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  });
+  setTimeout(() => {
+    if (flashMessageId.value === messageId) flashMessageId.value = null;
+  }, 1800);
+}
+
 function bumpLastActivity(jid, timestamp) {
   if (!jid) return;
   const ts = timestamp || new Date().toISOString();
@@ -115,6 +204,18 @@ api.onSSE('message', (data) => {
   clearTypingStateForJid(data.jid);
   clearAgentProgressForJid(data.jid);
   bumpLastActivity(data.jid, data.timestamp);
+
+  const notifGroup = groups.value.find((g) => g.jid === data.jid);
+  if (notifGroup && data.message_id) {
+    pushNotification({
+      id: data.message_id,
+      jid: data.jid,
+      groupName: notifGroup.name,
+      senderName: data.sender_name,
+      preview: truncatePreview(data.text),
+      timestamp: data.timestamp,
+    });
+  }
 
   if (data.jid === selectedJid.value) {
     messages.value = [
@@ -357,6 +458,50 @@ export async function loadGroups() {
   }
 }
 
+async function backfillNotifications() {
+  const allGroups = groups.value;
+  if (allGroups.length === 0) return;
+  const isFirstRun = notifications.value.length === 0
+    && Object.keys(notifLastReadAt.value).length === 0;
+  const seen = new Set(notifications.value.map((n) => n.id));
+  const results = await Promise.all(
+    allGroups.map((g) =>
+      api.getMessages(g.jid).then((d) => ({ g, msgs: d.messages })).catch(() => null),
+    ),
+  );
+  const collected = [];
+  for (const r of results) {
+    if (!r) continue;
+    for (const m of r.msgs) {
+      if (!m.is_bot_message || !m.id || seen.has(m.id)) continue;
+      collected.push({
+        id: m.id,
+        jid: r.g.jid,
+        groupName: r.g.name,
+        senderName: m.sender_name,
+        preview: truncatePreview(m.content),
+        timestamp: m.timestamp,
+      });
+    }
+  }
+  if (collected.length === 0) return;
+  const merged = [...notifications.value, ...collected]
+    .sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1))
+    .slice(0, NOTIF_MAX);
+  notifications.value = merged;
+  persistNotifications();
+  if (isFirstRun) {
+    // Treat everything pre-existing as read so the bell doesn't light up on
+    // first install. New SSE messages from here on will count as unread.
+    const nextRead = { ...notifLastReadAt.value };
+    for (const n of merged) {
+      if (!nextRead[n.jid] || n.timestamp > nextRead[n.jid]) nextRead[n.jid] = n.timestamp;
+    }
+    notifLastReadAt.value = nextRead;
+    persistNotifLastRead();
+  }
+}
+
 async function loadSessionPressure() {
   try {
     const data = await api.getSessionPressure();
@@ -391,6 +536,7 @@ export async function selectGroup(jid) {
   const cur = { ...unread.value };
   delete cur[jid];
   unread.value = cur;
+  markGroupNotificationsRead(jid);
 
   // Clear messages before fetch so SSE messages arriving during the fetch
   // are appended to a clean slate (selectedJid is already set above).
@@ -738,6 +884,6 @@ loadTheme();
 
 // --- Render ---
 
-loadGroups().then(loadSessionPressure);
+loadGroups().then(() => Promise.all([loadSessionPressure(), backfillNotifications()]));
 loadTriggers();
 render(html`<${App} />`, document.getElementById('app'));

--- a/web/js/components/ChatView.js
+++ b/web/js/components/ChatView.js
@@ -6,6 +6,7 @@ import { ChatInput } from './ChatInput.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 import { WorkStatusBanner } from './WorkStatusBanner.js';
 import { ContextPressureBanner } from './ContextPressureBanner.js';
+import { NotificationBell } from './NotificationBell.js';
 
 export function ChatView({ onOpenSidebar }) {
   const group = selectedGroup.value;
@@ -32,12 +33,15 @@ export function ChatView({ onOpenSidebar }) {
           </button>
           <h2 class="text-sm font-semibold">${group?.name || ''}</h2>
         </div>
-        ${hasMessages && html`
-          <button
-            class="text-xs text-txt-muted hover:text-err transition-colors"
-            onClick=${() => setClearOpen(true)}
-          >Clear chat</button>
-        `}
+        <div class="flex items-center gap-2">
+          ${hasMessages && html`
+            <button
+              class="text-xs text-txt-muted hover:text-err transition-colors"
+              onClick=${() => setClearOpen(true)}
+            >Clear chat</button>
+          `}
+          <${NotificationBell} />
+        </div>
       </div>
       <${WorkStatusBanner} />
       <${ContextPressureBanner} />

--- a/web/js/components/MessageList.js
+++ b/web/js/components/MessageList.js
@@ -12,6 +12,7 @@ import {
   currentWorkState,
   agentProgress,
   selectedJid,
+  flashMessageId,
 } from '../app.js';
 import { Message } from './Message.js';
 import { ThreadView } from './ThreadView.js';
@@ -101,8 +102,14 @@ export function MessageList() {
         : msgs.filter((m) => m.senderName !== 'System').map(
             (m, i) => {
               const thread = m.id ? threads[m.id] : null;
+              const flashing = m.id && flashMessageId.value === m.id;
               return html`
-                <div key=${i} data-role=${m.role}>
+                <div
+                  key=${i}
+                  data-role=${m.role}
+                  id=${m.id ? `msg-${m.id}` : undefined}
+                  class=${flashing ? 'notif-flash' : ''}
+                >
                   <${Message}
                     role=${m.role}
                     content=${m.content}

--- a/web/js/components/NotificationBell.js
+++ b/web/js/components/NotificationBell.js
@@ -1,0 +1,113 @@
+import { html } from 'htm/preact';
+import { useState, useRef, useEffect } from 'preact/hooks';
+import {
+  notifications,
+  notifLastReadAt,
+  unreadNotifCount,
+  navigateToMessage,
+  markAllNotificationsRead,
+} from '../app.js';
+
+function esc(s) {
+  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function formatRelative(ts) {
+  if (!ts) return '';
+  const then = new Date(ts).getTime();
+  if (Number.isNaN(then)) return '';
+  const diff = Date.now() - then;
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+export function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const count = unreadNotifCount.value;
+  const entries = notifications.value;
+  const lastRead = notifLastReadAt.value;
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setOpen(false);
+    };
+    setTimeout(() => document.addEventListener('click', handler), 0);
+    return () => document.removeEventListener('click', handler);
+  }, [open]);
+
+  function handleEntryClick(entry) {
+    setOpen(false);
+    navigateToMessage(entry.jid, entry.id);
+  }
+
+  return html`
+    <div ref=${wrapperRef} class="relative">
+      <button
+        class="relative w-8 h-8 flex items-center justify-center rounded-md text-txt-2 hover:bg-bg-hover hover:text-txt transition-colors"
+        title="Notifications"
+        onClick=${() => setOpen((v) => !v)}
+      >
+        <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"/>
+        </svg>
+        ${count > 0 && html`
+          <span class="absolute -top-0.5 -right-0.5 min-w-[16px] h-[16px] flex items-center justify-center rounded-full bg-accent text-bg text-[10px] font-semibold px-1">
+            ${count > 99 ? '99+' : count}
+          </span>
+        `}
+      </button>
+
+      ${open && html`
+        <div class="absolute right-0 top-full mt-1 z-50 w-80 max-w-[calc(100vw-1.5rem)] rounded-lg border border-border bg-bg-2 shadow-xl overflow-hidden">
+          <div class="flex items-center justify-between px-3 py-2 border-b border-border">
+            <span class="text-xs font-semibold text-txt">Notifications</span>
+            ${count > 0 && html`
+              <button
+                class="text-[11px] text-txt-muted hover:text-txt transition-colors"
+                onClick=${() => markAllNotificationsRead()}
+              >Mark all read</button>
+            `}
+          </div>
+          ${entries.length === 0
+            ? html`
+              <div class="px-3 py-6 text-center text-xs text-txt-muted">
+                No activity yet.
+              </div>
+            `
+            : html`
+              <div class="max-h-[min(70vh,28rem)] overflow-y-auto">
+                ${entries.map((n) => {
+                  const isUnread = !lastRead[n.jid] || n.timestamp > lastRead[n.jid];
+                  return html`
+                    <button
+                      key=${n.id}
+                      class="w-full text-left px-3 py-2 border-b border-border/60 last:border-b-0 hover:bg-bg-hover transition-colors flex gap-2"
+                      onClick=${() => handleEntryClick(n)}
+                    >
+                      <span
+                        class="w-1.5 h-1.5 rounded-full flex-shrink-0 mt-1.5 ${isUnread ? 'bg-accent' : 'bg-transparent'}"
+                        aria-hidden="true"
+                      />
+                      <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2 text-xs">
+                          <span class="font-semibold text-txt truncate">${esc(n.senderName || 'Agent')}</span>
+                          <span class="text-txt-muted truncate">${esc(n.groupName)}</span>
+                          <span class="text-txt-muted ml-auto shrink-0">${formatRelative(n.timestamp)}</span>
+                        </div>
+                        <div class="text-[11px] text-txt-2 line-clamp-2 mt-0.5 break-words">${esc(n.preview)}</div>
+                      </div>
+                    </button>
+                  `;
+                })}
+              </div>
+            `}
+        </div>
+      `}
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary
- Bell icon in the ChatView top bar with an unread count badge and dropdown of recent agent messages across all groups, newest first
- Clicking a notification switches to the source group, scrolls to the message, and flashes it briefly via a new `notif-flash` CSS animation anchored on a new `id="msg-<id>"` attribute in MessageList
- History and per-group last-read state persist to localStorage; backfill on page load pulls recent bot messages so the dropdown survives reloads. On first install, historical entries are auto-marked read so the bell starts at 0

## Test plan
- [x] Reload → bell shows no badge; dropdown is pre-populated from history (backfill)
- [x] Send a message in a non-selected group → badge increments; dropdown gets a new entry at the top
- [x] Click an entry → switches group, scrolls to the message with a brief accent flash
- [x] Open a group directly → its notifications become read; badge drops
- [x] "Mark all read" clears everything
- [x] Reload → history + read state persist via localStorage
- [x] Default "General" group (`isSystem: true`) is included correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)