### PR TITLE
Harden multi-agent coordinator context (#65)

### DIFF
--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -184,12 +184,26 @@ export function buildMultiAgentContext(
 
   if (isCoordinator) {
     if (profile.receivesMcpTools) {
+      // Only specialists (agents with a trigger) are valid delegation targets.
+      // Enumerate every specialist with a concrete example so the model pattern-
+      // matches against the full topology rather than extrapolating from one.
+      const specialists = others.filter((a) => !!a.trigger);
+      const delegationExamples =
+        specialists.length > 0
+          ? specialists
+              .map(
+                (a) =>
+                  `  delegate_to_agent({ agent: "${a.name}", message: "Specific instructions for ${a.displayName}...", completion_policy: "final_response" })`,
+              )
+              .join('\n')
+          : `  delegate_to_agent({ agent: "agent-name", message: "Specific instructions...", completion_policy: "final_response" })`;
+
       lines.push(
         `You are the coordinator. You handle general questions directly and delegate specialist work.`,
         `For meaningful ongoing work, keep sidebar presence current: use mcp__nanoclaw__set_subtitle for the team-level summary, and use mcp__nanoclaw__set_agent_status for your own row if you have one.`,
         `Set concise, high-signal statuses when work starts ("Reviewing PRs", "Waiting on Scout") and clear them when the work is done.`,
-        `To delegate, use the mcp__nanoclaw__delegate_to_agent tool:`,
-        `  delegate_to_agent({ agent: "${others[0]?.name || 'agent'}", message: "Specific instructions...", completion_policy: "final_response" })`,
+        `To delegate, use the mcp__nanoclaw__delegate_to_agent tool. Valid targets and example invocations:`,
+        delegationExamples,
         `Use completion_policy: "final_response" by default. Only use "retrigger_coordinator" when you specifically need a follow-up turn to combine or interpret specialist results.`,
         `The target agent runs after your turn. Their user-visible output may be suppressed if newer context arrives before it is delivered.`,
         `Even when a specialist's user-visible output is suppressed, the system records that completion for you in the conversation so you can decide whether to reuse it, summarize it, or move on.`,
@@ -201,6 +215,11 @@ export function buildMultiAgentContext(
         `If delegated browser work hits a blocker like a login wall, captcha, modal trap, missing control, or broken layout, publish one screenshot with a short caption before asking for guidance.`,
         ``,
         `Silent chaining: when a specialist just finished and you are simply passing the baton to the next one in a sequence, delegate without a visible message. Only respond visibly when synthesizing results, making a decision, or all specialists in the current batch have reported back. Do not narrate each handoff.`,
+        ``,
+        // Self-check sits at the bottom of the context block so it lands closest
+        // to the user turn boundary — the highest-attention position in a
+        // system-prompt-appended context. See #65.
+        `Before you finalize your response: if any part of your reply describes handing work off ("I'll ask X to look at this", "Let me delegate to X"), confirm you actually invoked mcp__nanoclaw__delegate_to_agent for that handoff. Describing a delegation in prose is narration — it does not run the tool. If you meant to delegate, invoke the tool now.`,
       );
     } else {
       // Tool-less coordinator: can't actually delegate. Be honest about the

--- a/src/index.ts
+++ b/src/index.ts
@@ -1828,6 +1828,17 @@ async function runAgent(
             },
             'Agent run usage stored',
           );
+          if (agent && !agent.trigger) {
+            logger.info(
+              {
+                event: 'multi_agent.coordinator_turn_completed',
+                agent: agentId,
+                runBatchId,
+                numTurns: u.numTurns,
+              },
+              'Coordinator turn completed',
+            );
+          }
           checkContextPressure(group.folder, chatJid);
         }
       }
@@ -1920,6 +1931,17 @@ async function runAgent(
         },
         'Agent run usage stored',
       );
+      if (agent && !agent.trigger) {
+        logger.info(
+          {
+            event: 'multi_agent.coordinator_turn_completed',
+            agent: agentId,
+            runBatchId,
+            numTurns: u.numTurns,
+          },
+          'Coordinator turn completed',
+        );
+      }
       checkContextPressure(group.folder, chatJid);
     }
   };
@@ -3025,9 +3047,11 @@ async function main(): Promise<void> {
 
       logger.info(
         {
+          event: 'multi_agent.delegation_invoked',
           group: group.name,
           source: sourceAgent,
           target: targetAgent,
+          sourceBatchId,
           messageLen: message.length,
         },
         'Processing agent delegation',

--- a/src/model-capabilities.test.ts
+++ b/src/model-capabilities.test.ts
@@ -162,4 +162,40 @@ describe('buildMultiAgentContext', () => {
     const out = buildMultiAgentContext(ollamaSpec, [coord, ollamaSpec]);
     expect(out).toContain('Coord');
   });
+
+  it('enumerates every specialist with its own delegation example', () => {
+    const analyst = agent({
+      id: 'web_team/analyst',
+      name: 'analyst',
+      displayName: 'Analyst',
+      trigger: '@analyst',
+    });
+    const reviewer = agent({
+      id: 'web_team/reviewer',
+      name: 'reviewer',
+      displayName: 'Reviewer',
+      trigger: '@reviewer',
+    });
+    const out = buildMultiAgentContext(coord, [coord, analyst, reviewer]);
+    expect(out).toContain('agent: "analyst"');
+    expect(out).toContain('agent: "reviewer"');
+  });
+
+  it('omits other coordinators from delegation examples (only triggered specialists)', () => {
+    const secondCoord = agent({
+      id: 'web_team/coord2',
+      name: 'coord2',
+      displayName: 'Coord2',
+    });
+    const out = buildMultiAgentContext(coord, [coord, secondCoord, spec]);
+    // Only `spec` has a trigger; `coord2` must not appear as a delegation target.
+    expect(out).toContain('agent: "spec"');
+    expect(out).not.toContain('agent: "coord2"');
+  });
+
+  it('tool-capable coordinator includes a pre-response self-check against narration', () => {
+    const out = buildMultiAgentContext(coord, [coord, spec]);
+    expect(out).toContain('narration');
+    expect(out).toMatch(/invoke.*tool/i);
+  });
 });


### PR DESCRIPTION
## Summary

Residual hardening for #65 — the `buildMultiAgentContext` layer landed some time ago with runtime-aware branching, but three reliability items from the issue were still open:

- **Enumerate every specialist** with its own `delegate_to_agent` example. Previously the block used a single `others[0]` prototype, leaving the model to extrapolate to the rest of the topology — empirically, it didn't.
- **Pre-response self-check** at the bottom of the coordinator context block, sitting right at the user-turn boundary where attention is highest. Catches narration-of-delegation (\"I'll ask X to look at this\") that never invokes the tool.
- **Instrumentation** for invoke-vs-narrate. Two structured events (`multi_agent.delegation_invoked` + `multi_agent.coordinator_turn_completed`) correlatable by `runBatchId` / `sourceBatchId`, so we can grep logs and quantify coordinator drift without adding a counter or shared state.

Only the tool-capable coordinator branch is affected. Tool-less (small-Ollama) coordinator / specialist branches are untouched — delegation doesn't apply there.

## Design note on ordering

The issue proposed prepending the multi-agent block. After tracing the composition in both runtimes (`claude-runtime.ts:434–447` appends via `systemPrompt.append`; `ollama-runtime.ts:192–202` appends to a `systemParts` array), the block already sits at the end of the system prompt — which is the high-attention position closest to the user turn. No ordering change needed; the new self-check is placed as the final bullet so it lands at that boundary.

## Test plan

- [x] 491 unit tests pass (3 new tests added for enumeration, coordinator filtering, self-check)
- [x] `npm run build` clean
- [ ] Post-merge: smoke with a multi-specialist team via `/test-agent`, grep logs for `multi_agent.delegation_invoked` vs `multi_agent.coordinator_turn_completed` to verify the correlation

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)