### PR TITLE
Reject too-short delegation messages (#48)

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -16,6 +16,10 @@ const IPC_DIR = '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
 const TASKS_DIR = path.join(IPC_DIR, 'tasks');
 
+// Keep in sync with MIN_DELEGATION_MESSAGE_LENGTH in src/delegation-validation.ts.
+// Container is a separate TS project so we can't import from the host code.
+const MIN_DELEGATION_MESSAGE_LENGTH = 40;
+
 // Context from environment variables (set by the agent runner)
 const chatJid = process.env.NANOCLAW_CHAT_JID!;
 const groupFolder = process.env.NANOCLAW_GROUP_FOLDER!;
@@ -866,6 +870,21 @@ Example: delegate_to_agent({ agent: "analyst", message: "Please analyze the thre
       completion_policy: z.enum(['final_response', 'retrigger_coordinator']).default('final_response').describe('What happens after the specialist responds. "final_response" (default): the specialist\'s output is the final answer, you do NOT get a follow-up turn. "retrigger_coordinator": you get a follow-up turn to review and synthesize. Use retrigger_coordinator only when delegating to multiple agents and you need to combine their outputs.'),
     },
     async (args) => {
+      // Platform-level validation (#48): specialists see only this message,
+      // not the coordinator's conversation. Reject obviously insufficient
+      // payloads so the coordinator can self-correct instead of wasting a
+      // ~30-60s specialist container startup on an empty prompt.
+      const trimmedMessage = (args.message ?? '').trim();
+      if (trimmedMessage.length < MIN_DELEGATION_MESSAGE_LENGTH) {
+        return {
+          isError: true,
+          content: [{
+            type: 'text' as const,
+            text: `Delegation rejected: message is too short (${trimmedMessage.length} chars, minimum ${MIN_DELEGATION_MESSAGE_LENGTH}). The target agent runs in its own container and sees ONLY this message — they do not have your conversation history. Retry the tool call with: what you specifically need, any context (ticket IDs, paths, prior findings), and the expected output format.`,
+          }],
+        };
+      }
+
       const DELEGATIONS_DIR = path.join(IPC_DIR, 'delegations');
       writeIpcFile(DELEGATIONS_DIR, {
         type: 'delegate',

--- a/src/delegation-validation.test.ts
+++ b/src/delegation-validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MIN_DELEGATION_MESSAGE_LENGTH,
+  validateDelegationMessage,
+} from './delegation-validation.js';
+
+describe('validateDelegationMessage', () => {
+  it('rejects an empty message', () => {
+    const result = validateDelegationMessage('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/too short/i);
+      expect(result.reason).toContain(String(MIN_DELEGATION_MESSAGE_LENGTH));
+    }
+  });
+
+  it('rejects a whitespace-only message', () => {
+    const result = validateDelegationMessage('   \n\t  ');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a terse message under the minimum', () => {
+    const result = validateDelegationMessage('triage this');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects right at the boundary (minimum - 1)', () => {
+    const msg = 'x'.repeat(MIN_DELEGATION_MESSAGE_LENGTH - 1);
+    expect(validateDelegationMessage(msg).ok).toBe(false);
+  });
+
+  it('accepts right at the boundary (minimum)', () => {
+    const msg = 'x'.repeat(MIN_DELEGATION_MESSAGE_LENGTH);
+    expect(validateDelegationMessage(msg).ok).toBe(true);
+  });
+
+  it('accepts a contextful delegation', () => {
+    const result = validateDelegationMessage(
+      'Review PR #123 at acme/repo and summarize the main risks in bullet form.',
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects when the trimmed length is under the minimum (leading/trailing whitespace does not count)', () => {
+    const shortCore = 'x'.repeat(MIN_DELEGATION_MESSAGE_LENGTH - 5);
+    const padded = `    ${shortCore}    `;
+    expect(validateDelegationMessage(padded).ok).toBe(false);
+  });
+
+  it('handles undefined-ish input without throwing', () => {
+    const result = validateDelegationMessage(undefined as unknown as string);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/delegation-validation.ts
+++ b/src/delegation-validation.ts
@@ -1,0 +1,29 @@
+/**
+ * Platform-level validation for coordinator → specialist delegations.
+ *
+ * Specialists run in their own container with isolated conversation history —
+ * they see only the delegation message, not the coordinator's prior turns.
+ * A message like "triage this bug" without ticket ID, summary, or subsystem
+ * hints wastes a ~30–60s specialist container startup on insufficient context.
+ *
+ * Kept as a pure function so the check is identical on both sides of the
+ * IPC boundary (MCP tool inside the container, and onDelegateToAgent on the
+ * host as a backstop against stale container images).
+ */
+
+export const MIN_DELEGATION_MESSAGE_LENGTH = 40;
+
+export type DelegationValidation = { ok: true } | { ok: false; reason: string };
+
+export function validateDelegationMessage(
+  message: string,
+): DelegationValidation {
+  const trimmed = (message ?? '').trim();
+  if (trimmed.length < MIN_DELEGATION_MESSAGE_LENGTH) {
+    return {
+      ok: false,
+      reason: `Delegation message is too short (${trimmed.length} chars, minimum ${MIN_DELEGATION_MESSAGE_LENGTH}). The target agent runs in its own container and sees ONLY this message — they do not have access to your conversation history. Include: what you specifically need, any context (ticket IDs, paths, prior findings), and the expected output format.`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   buildMultiAgentContext,
   discoverAgents,
 } from './agent-discovery.js';
+import { validateDelegationMessage } from './delegation-validation.js';
 import { setActiveAgentName, clearActiveAgentName } from './agent-state.js';
 import { getTriggeredAgentsForMessages } from './agent-routing.js';
 import {
@@ -3015,6 +3016,27 @@ async function main(): Promise<void> {
         sourceBatchId,
         completionPolicy,
       } = request;
+
+      // Platform-level backstop (#48). Duplicates the check the MCP tool
+      // already applies in the coordinator container — this catches the
+      // case where the container image is stale (pre-validation) and would
+      // otherwise waste a ~30-60s specialist startup on hollow context.
+      const validation = validateDelegationMessage(message);
+      if (!validation.ok) {
+        logger.warn(
+          {
+            event: 'multi_agent.delegation_rejected',
+            sourceGroup,
+            sourceAgent,
+            targetAgent,
+            sourceBatchId,
+            messageLen: (message ?? '').trim().length,
+            reason: validation.reason,
+          },
+          'Delegation rejected: insufficient message context',
+        );
+        return;
+      }
 
       // Find the group JID from the source folder
       const groupJid = Object.keys(registeredGroups).find(


### PR DESCRIPTION
## Summary

Closes #48. Specialists run in isolated containers and see **only the delegation message** — not the coordinator's conversation. Hollow payloads like `"help"` or `"triage this"` waste a ~30-60s specialist startup on context they can't succeed with.

Platform now rejects messages under 40 characters (trimmed) on both sides of the IPC boundary:

- **Container-side (MCP tool, `ipc-mcp-stdio.ts`)** — `delegate_to_agent` returns `{ isError: true, content: [...] }` for short messages. Coordinator sees the error mid-turn and can self-correct with a fuller message.
- **Host-side backstop (`onDelegateToAgent`)** — duplicates the check as defense against stale container images that predate this validation. Emits `multi_agent.delegation_rejected` log event and skips enqueue.
- **Shared validator (`src/delegation-validation.ts`)** — pure function, testable. Container duplicates the 40-char constant (separate TS project, no cross-project imports).

## Why a rejection, not a warning

The issue proposed four approaches (minimum length, structure hints, coordinator prompt injection, post-hoc audit). Rejection is the highest-leverage option because:
1. The coordinator sees the error immediately and can retry with context in the same turn — no specialist container spawned at all
2. A warning-only flow lets the specialist run anyway and produce bad output; nothing is recovered
3. 40 chars is conservative — allows terse-but-specific delegations like `"Review PR acme/repo#123 and list main risks"` (46 chars)

## Smoke test (verified end-to-end)

Sent a dual-delegation message asking the coordinator to delegate to the Analyst with message `"help"` and to the Writer with a full descriptive prompt. Coordinator's response:

> - **Analyst (`"help"`)** — **rejected.** The tool enforces a minimum message length of 40 characters; 4 chars was too short.
> - **Writer (full descriptive message)** — **accepted.** Delegation went through normally.

Writer delivered its metaphor; Analyst never spawned a container. `multi_agent.delegation_invoked` fired only for Writer. No `multi_agent.delegation_rejected` on the host — the container-side tool caught it first (the intended fast path).

## Test plan

- [x] 8 unit tests for `validateDelegationMessage` (empty / whitespace / boundary / accepted / undefined-ish / padded)
- [x] 499 total host tests passing (`npx vitest run`)
- [x] `npm run build` clean
- [x] Container rebuilt (`./container/build.sh`) and service restarted
- [x] Live smoke with `@coordinator` in `web_test-team` — both reject + accept paths exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)