### PR TITLE
Context-audit skill + compaction visibility (#50)

### DIFF
--- a/.claude/skills/context-audit/SKILL.md
+++ b/.claude/skills/context-audit/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: context-audit
+description: Audit the context layers for a group or agent. Reports which CLAUDE.md files are in play, lists loaded skills with line counts, and flags any skill over the ~150-line compaction threshold where content may be silently truncated. Use when debugging agent drift, before shipping a new skill, or when an agent seems to ignore rules you thought were loaded. Triggers on "context audit", "audit context", "check compaction", "why is the agent ignoring X", or "/context-audit".
+---
+
+# Context Audit
+
+Inspect what context layers feed into an agent or group, and surface compaction-risk skills before they cause silent reliability bugs.
+
+## Why
+
+Claude Code auto-compacts skill files past ~5K tokens each (~150 lines), with a 25K-token combined skill budget. **CLAUDE.md files are always loaded in full.** Rules placed in skills but not CLAUDE.md can vanish silently during long conversations — the agent never sees them and the user can't tell it lost them.
+
+This skill doesn't fix anything. It shows you the shape of the context so you can move critical rules into CLAUDE.md (always loaded) and push reference material into `references/` (loaded on-demand).
+
+Full background in issue #50.
+
+## Usage
+
+The user provides:
+- **Target** — a group name (e.g. `test-team`) or the literal word `global` for repo-wide skills. If not given, ask.
+
+Optional:
+- **Threshold** — override the default 150-line compaction warning (e.g. `threshold=200`).
+
+## Steps
+
+### 1. Resolve the target
+
+Group targets resolve to `groups/{folder}/`. If the user gave a group name without the `web_` prefix, try both.
+
+```bash
+GROUP="test-team"
+GROUP_DIR=""
+for candidate in "groups/${GROUP}" "groups/web_${GROUP}"; do
+  if [ -d "$candidate" ]; then GROUP_DIR="$candidate"; break; fi
+done
+[ -z "$GROUP_DIR" ] && echo "No such group: $GROUP" && exit 1
+```
+
+### 2. Inventory CLAUDE.md layers
+
+These always survive compaction. Report which exist and their line counts:
+
+```bash
+for f in \
+  "groups/global/CLAUDE.md" \
+  "groups/global-web/CLAUDE.md" \
+  "${GROUP_DIR}/CLAUDE.md" \
+  "${GROUP_DIR}/agents"/*/CLAUDE.md; do
+  [ -f "$f" ] && printf "%4d  %s\n" "$(wc -l < "$f")" "$f"
+done
+```
+
+### 3. Inventory container skills
+
+Container skills load into every agent in the group at spawn time. Scan `container/skills/` for each SKILL.md and flag any over the threshold:
+
+```bash
+THRESHOLD=${THRESHOLD:-150}
+echo "Container skills (loaded into every agent in $GROUP):"
+for f in container/skills/*/SKILL.md; do
+  lines=$(wc -l < "$f")
+  name=$(basename "$(dirname "$f")")
+  if [ "$lines" -gt "$THRESHOLD" ]; then
+    echo "  ⚠  $name: $lines lines (over threshold — content past line $THRESHOLD may be truncated)"
+  else
+    echo "  ✓  $name: $lines lines"
+  fi
+done
+```
+
+### 4. Peek at what's past the threshold
+
+For each over-threshold skill, show the first 5 lines of content past the threshold. Critical rules placed there are the most at-risk:
+
+```bash
+for f in container/skills/*/SKILL.md; do
+  lines=$(wc -l < "$f")
+  name=$(basename "$(dirname "$f")")
+  if [ "$lines" -gt "$THRESHOLD" ]; then
+    echo
+    echo "--- $name: content past line $THRESHOLD (compaction risk) ---"
+    sed -n "$((THRESHOLD + 1)),$((THRESHOLD + 20))p" "$f"
+  fi
+done
+```
+
+### 5. Report and recommend
+
+Present a concise summary. Example:
+
+```
+Group: test-team (groups/web_test-team/)
+
+CLAUDE.md layers (always loaded):
+  92   groups/global/CLAUDE.md
+  47   groups/global-web/CLAUDE.md
+  34   groups/web_test-team/CLAUDE.md
+  28   groups/web_test-team/agents/coordinator/CLAUDE.md
+  22   groups/web_test-team/agents/analyst/CLAUDE.md
+
+Container skills (compaction threshold: 150 lines):
+  ✓  status: 89 lines
+  ✓  capabilities: 134 lines
+  ⚠  agent-browser: 170 lines (20 lines past threshold)
+  ⚠  credential-proxy: 217 lines (67 lines past threshold)
+  ⚠  rich-output: 291 lines (141 lines past threshold)
+
+Recommendations:
+  - rich-output has substantial content past line 150. Any MUST-follow rules in that
+    tail should be moved to groups/global-web/CLAUDE.md or the relevant group CLAUDE.md,
+    with reference material pushed into rich-output/references/.
+  - Apply the same check to credential-proxy and agent-browser.
+```
+
+### 6. Flag specific rule patterns (optional)
+
+If the user asks for a deeper scan, grep for imperative patterns inside the at-risk region and surface them as "critical rules at risk":
+
+```bash
+for f in container/skills/*/SKILL.md; do
+  lines=$(wc -l < "$f")
+  if [ "$lines" -gt "$THRESHOLD" ]; then
+    name=$(basename "$(dirname "$f")")
+    tail -n +$((THRESHOLD + 1)) "$f" \
+      | grep -niE "^[#>*-]*\s*(never|always|must|only|do not|never use|required)" \
+      | head -5 \
+      | awk -v n="$name" -v offset="$THRESHOLD" -F: \
+          '{printf "  %s (line ~%d): %s\n", n, $1 + offset, $2}'
+  fi
+done
+```
+
+These are the highest-leverage candidates to lift into a CLAUDE.md layer.
+
+## When to run
+
+- **Before shipping a new skill** — verify it fits under the threshold, or at least that nothing past line 150 is load-bearing
+- **When an agent ignores a rule you added** — likely the rule is past the compaction cutoff and never reached the model
+- **Periodically** — as skills grow, new compaction risks appear. Monthly is reasonable
+- **After a compaction-related bug** — confirm the fix landed in a durable layer (CLAUDE.md, not just a skill)
+
+## What this skill does NOT do
+
+- Rewrite skills to meet the threshold (that's #26 / `/skills` maintenance work)
+- Validate skill frontmatter (that's `scripts/validate-skills.mjs`)
+- Report host-side Claude Code skills for the dev user's own workflow (scope is container agents)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,9 @@ Instructions here...
 
 **Rules:**
 - Keep SKILL.md **under 500 lines** — move detail to separate reference files
+- Prefer **under 150 lines** — Claude Code compacts each skill past ~5K tokens (~150 lines) during long conversations. Content past that point may be silently truncated. `scripts/validate-skills.mjs` emits non-blocking warnings over this threshold; run `/context-audit` to inspect what's at risk for a given group.
+- **Critical rules belong in a CLAUDE.md layer**, not only in a skill. CLAUDE.md files are always loaded in full — rules an agent MUST follow (output formats, safety invariants, protocol requirements) should live there so compaction can't drop them. Use skills for reference material, workflows, and optional guidance.
+- Put the non-negotiable rules **at the top** of the SKILL.md, detail and examples lower down. If compaction hits, the high-value content survives.
 - `name`: lowercase, alphanumeric + hyphens, max 64 chars
 - `description`: required — Claude uses this to decide when to invoke the skill
 - Put code in separate files, not inline in the markdown

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -5,6 +5,10 @@
 //   - `name` matches the skill's directory
 //   - File length <= MAX_LINES
 //
+// Also emits soft warnings (non-failing) for skills over the Claude Code
+// compaction threshold (~150 lines / ~5K tokens each) where content past
+// that point may be silently truncated during long conversations. See #50.
+//
 // Usage:
 //   node scripts/validate-skills.mjs                       # audit every SKILL.md
 //   node scripts/validate-skills.mjs path/to/SKILL.md ...  # validate specific files
@@ -13,6 +17,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const MAX_LINES = 500;
+const COMPACTION_SOFT_WARNING = 150;
 const SKILL_ROOTS = ['.claude/skills', 'container/skills'];
 
 function findAllSkills() {
@@ -30,6 +35,7 @@ function findAllSkills() {
 
 function validate(filePath) {
   const errors = [];
+  const warnings = [];
   const rel = path.relative(process.cwd(), filePath);
   const dirName = path.basename(path.dirname(filePath));
 
@@ -37,7 +43,7 @@ function validate(filePath) {
   try {
     content = fs.readFileSync(filePath, 'utf-8');
   } catch (err) {
-    return [`${rel}: cannot read file (${err.message})`];
+    return { errors: [`${rel}: cannot read file (${err.message})`], warnings };
   }
 
   const lines = content.split('\n');
@@ -45,19 +51,23 @@ function validate(filePath) {
     errors.push(
       `${rel}: ${lines.length} lines exceeds the ${MAX_LINES}-line limit — move detail to a reference file`,
     );
+  } else if (lines.length > COMPACTION_SOFT_WARNING) {
+    warnings.push(
+      `${rel}: ${lines.length} lines exceeds the ${COMPACTION_SOFT_WARNING}-line compaction threshold — content past line ${COMPACTION_SOFT_WARNING} may be silently truncated by Claude Code. Put critical rules above that point or lift them into a CLAUDE.md layer (see /context-audit).`,
+    );
   }
 
   if (lines[0] !== '---') {
     errors.push(
       `${rel}: missing frontmatter — file must start with "---" on the first line`,
     );
-    return errors;
+    return { errors, warnings };
   }
 
   const closeIdx = lines.indexOf('---', 1);
   if (closeIdx === -1) {
     errors.push(`${rel}: frontmatter has no closing "---"`);
-    return errors;
+    return { errors, warnings };
   }
 
   const fm = lines.slice(1, closeIdx);
@@ -83,7 +93,7 @@ function validate(filePath) {
     errors.push(`${rel}: frontmatter missing required "description" field`);
   }
 
-  return errors;
+  return { errors, warnings };
 }
 
 const args = process.argv.slice(2);
@@ -98,8 +108,19 @@ if (targets.length === 0) {
 }
 
 const allErrors = [];
+const allWarnings = [];
 for (const file of targets) {
-  allErrors.push(...validate(file));
+  const { errors, warnings } = validate(file);
+  allErrors.push(...errors);
+  allWarnings.push(...warnings);
+}
+
+if (allWarnings.length > 0) {
+  console.warn(
+    `skill compaction warnings (${allWarnings.length}; non-blocking):\n`,
+  );
+  for (const w of allWarnings) console.warn(`  • ${w}`);
+  console.warn('');
 }
 
 if (allErrors.length > 0) {


### PR DESCRIPTION
## Summary

Closes #50. Surface the silent skill-compaction gap before it causes drift. Claude Code compacts skill files past ~5K tokens each (~150 lines) during long conversations; rules placed there but not in a CLAUDE.md layer can vanish without any signal to the user or agent. Three complementary changes:

### 1. New `/context-audit` operational skill
`.claude/skills/context-audit/SKILL.md` (148 lines, intentionally under its own threshold). Takes a group name and reports:
- Which CLAUDE.md layers are in play (always loaded), with line counts
- Which container skills load into every agent, with line counts, flagging any over the 150-line compaction cutoff
- A preview of the first 20 lines of at-risk content past the threshold
- A recommendation to lift load-bearing rules into a CLAUDE.md layer

Use it when debugging agent drift, before shipping a new skill, or when an agent seems to ignore a rule you thought was loaded.

### 2. Soft compaction warning in `validate-skills.mjs`
Non-blocking warning at 150 lines. The existing 500-line hard cap is unchanged. Dry-run on this repo surfaces 22 skills over the threshold, ending in `✓ 40 skill file(s) pass validation`. Pre-commit continues to pass; developers see the warning at commit time and can act.

### 3. Codify the pattern in `CONTRIBUTING.md`
Three new bullets under the SKILL.md rules:
- Prefer under 150 lines (compaction threshold)
- Critical rules belong in a CLAUDE.md layer, not only in a skill
- Top-load the non-negotiable content so compaction can't drop it

## Why not enforce?

The issue proposed four options. Rejection (hard fail at 150) would break 22 existing skills immediately. The soft warning + new skill combination:
- Lets existing skills keep working while the remediation effort tracked in #26 proceeds
- Gives developers and users the tool to inspect what's at risk for a specific group, not the whole repo
- Creates pressure at commit time (warning) and at runtime debugging (skill), not a single gate

Full skill priority/pinning (issue option 4) needs SDK support and stays out of scope.

## Verification

Ran the skill's bash steps against `web_test-team`:
```
--- CLAUDE.md layers ---
 278  groups/global/CLAUDE.md
 ...
--- Container skills (threshold=150) ---
  WARN  agent-browser: 170 lines
  OK    capabilities: 100 lines
  WARN  credential-proxy: 217 lines
  WARN  rich-output: 291 lines
  OK    slack-formatting: 94 lines
  OK    status: 104 lines
```

rich-output (291) is the exact skill the issue cites as motivation — the audit surfaces it without any per-repo hand-tuning.

## Test plan

- [x] `node scripts/validate-skills.mjs` — 22 warnings, 0 errors, exit 0
- [x] 499 host tests passing (no code changes)
- [x] Skill shows up in the available-skills list at runtime
- [x] Dry-run of skill's bash steps against a real group

🤖 Generated with [Claude Code](https://claude.com/claude-code)