### PR TITLE
Per-agent skill selection (#42, Phase 3 of #74)

### DIFF
--- a/src/agent-discovery.test.ts
+++ b/src/agent-discovery.test.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadAgentFromDir } from './agent-discovery.js';
+
+describe('loadAgentFromDir — agent.json parsing', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-discovery-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function writeAgentJson(config: Record<string, unknown>): string {
+    const agentDir = path.join(tmpRoot, 'agent');
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, 'CLAUDE.md'), '# test\n');
+    fs.writeFileSync(path.join(agentDir, 'agent.json'), JSON.stringify(config));
+    return agentDir;
+  }
+
+  it('defaults skills and tools to undefined when agent.json omits them', () => {
+    const agentDir = writeAgentJson({
+      displayName: 'Stub',
+      trigger: '@stub',
+    });
+    const agent = loadAgentFromDir('web_test', 'stub', agentDir);
+    expect(agent.tools).toBeUndefined();
+    expect(agent.skills).toBeUndefined();
+  });
+
+  it('loads skills as a string array when provided', () => {
+    const agentDir = writeAgentJson({
+      skills: ['rich-output', 'status'],
+    });
+    const agent = loadAgentFromDir('web_test', 'stub', agentDir);
+    expect(agent.skills).toEqual(['rich-output', 'status']);
+  });
+
+  it('preserves an empty skills array ("no skills" opt-out)', () => {
+    const agentDir = writeAgentJson({ skills: [] });
+    const agent = loadAgentFromDir('web_test', 'stub', agentDir);
+    expect(agent.skills).toEqual([]);
+  });
+
+  it('drops non-string entries in the skills array', () => {
+    const agentDir = writeAgentJson({
+      skills: ['rich-output', 42, null, 'status'],
+    });
+    const agent = loadAgentFromDir('web_test', 'stub', agentDir);
+    expect(agent.skills).toEqual(['rich-output', 'status']);
+  });
+
+  it('ignores skills when the value is not an array', () => {
+    const agentDir = writeAgentJson({
+      skills: 'rich-output',
+    });
+    const agent = loadAgentFromDir('web_test', 'stub', agentDir);
+    expect(agent.skills).toBeUndefined();
+  });
+
+  it('loads tools and skills independently without cross-contamination', () => {
+    const agentDir = writeAgentJson({
+      tools: ['WebSearch'],
+      skills: ['agent-browser'],
+    });
+    const agent = loadAgentFromDir('web_test', 'stub', agentDir);
+    expect(agent.tools).toEqual(['WebSearch']);
+    expect(agent.skills).toEqual(['agent-browser']);
+  });
+});

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -87,7 +87,7 @@ function makeImplicitAgent(group: RegisteredGroup): Agent {
   };
 }
 
-function loadAgentFromDir(
+export function loadAgentFromDir(
   groupFolder: string,
   agentName: string,
   agentDir: string,
@@ -113,6 +113,11 @@ function loadAgentFromDir(
       if (Array.isArray(config.tools)) {
         agent.tools = config.tools.filter(
           (t: unknown): t is string => typeof t === 'string',
+        );
+      }
+      if (Array.isArray(config.skills)) {
+        agent.skills = config.skills.filter(
+          (s: unknown): s is string => typeof s === 'string',
         );
       }
     } catch (err) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -78,6 +78,10 @@ export interface ContainerInput {
   constraints?: RuntimeTurnConstraints; // per-turn safety rails (maxTurns, disallowedTools)
   systemContext?: string; // multi-agent context injected into systemPrompt.append (survives compaction)
   achievements?: { id: string; name: string; description: string }[];
+  // Optional positive allowlist over container/skills/*. Undefined = copy
+  // every global skill (backward compat). Empty array = copy none.
+  // See Phase 3 of #74 / #42.
+  skillsAllowlist?: string[];
 }
 
 export interface UsageData {
@@ -151,6 +155,7 @@ function buildVolumeMounts(
   isMain: boolean,
   chatJid: string,
   agentName?: string,
+  skillsAllowlist?: string[],
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -252,13 +257,36 @@ function buildVolumeMounts(
     );
   }
 
-  // Sync skills from container/skills/ into each group's .claude/skills/
+  // Sync skills from container/skills/ into each group's .claude/skills/.
+  // Per-agent allowlist (Phase 3 of #74 / #42): when skillsAllowlist is
+  // provided, only matching skill directories are copied. Undefined
+  // preserves the receive-all behavior for backward compatibility.
   const skillsSrc = path.join(process.cwd(), 'container', 'skills');
   const skillsDst = path.join(groupSessionsDir, 'skills');
   if (fs.existsSync(skillsSrc)) {
-    for (const skillDir of fs.readdirSync(skillsSrc)) {
+    const globalSkillDirs = fs
+      .readdirSync(skillsSrc)
+      .filter((d) => fs.statSync(path.join(skillsSrc, d)).isDirectory());
+    const allow = skillsAllowlist ? new Set(skillsAllowlist) : null;
+
+    // When an allowlist is set, remove any previously-copied global skills
+    // that are no longer in the allowlist. Only touch directories that
+    // match known global skill names — anything else in the skills dir is
+    // left alone (host-side Claude Code skills, user additions, etc).
+    if (allow && fs.existsSync(skillsDst)) {
+      for (const existing of fs.readdirSync(skillsDst)) {
+        if (globalSkillDirs.includes(existing) && !allow.has(existing)) {
+          fs.rmSync(path.join(skillsDst, existing), {
+            recursive: true,
+            force: true,
+          });
+        }
+      }
+    }
+
+    for (const skillDir of globalSkillDirs) {
+      if (allow && !allow.has(skillDir)) continue;
       const srcDir = path.join(skillsSrc, skillDir);
-      if (!fs.statSync(srcDir).isDirectory()) continue;
       const dstDir = path.join(skillsDst, skillDir);
       fs.cpSync(srcDir, dstDir, { recursive: true });
     }
@@ -718,6 +746,7 @@ export async function spawnContainer(
     input.isMain,
     input.chatJid,
     input.agentName,
+    input.skillsAllowlist,
   );
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const agentSuffix =

--- a/src/index.ts
+++ b/src/index.ts
@@ -2076,6 +2076,7 @@ async function runAgent(
         poolManaged: true,
         mainChatJid: isMain ? undefined : getMainChatJid(),
         systemContext,
+        skillsAllowlist: agent?.skills,
         achievements: getAchievementsForContainer(),
       };
 
@@ -2153,6 +2154,7 @@ async function runAgent(
       poolManaged: false,
       mainChatJid: isMain ? undefined : getMainChatJid(),
       systemContext,
+      skillsAllowlist: agent?.skills,
       achievements: getAchievementsForContainer(),
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,11 @@ export interface Agent {
   // wildcards on Claude (e.g. `mcp__nanoclaw__*`); Ollama matches exact
   // names only. An empty array means "no tools" — an explicit opt-out.
   tools?: string[];
+  // Positive skill allowlist over container/skills/*. Entries are skill
+  // directory names (e.g. "rich-output", "status"). Undefined preserves
+  // backward-compat behavior of receiving every global skill. An empty
+  // array means "no skills". Phase 3 of #74 / #42.
+  skills?: string[];
 }
 
 export type WorkPhase =


### PR DESCRIPTION
## Summary

Closes #42. Completes Phase 3 of #74 by mirroring the per-agent `tools` allowlist (shipped in Phase 2) for skills. Agents can now declare a narrow skills allowlist in `agent.json` that filters `container/skills/*` at copy time:

```json
{
  "displayName": "Researcher",
  "trigger": "@researcher",
  "tools": ["mcp__nanoclaw__send_message", "WebSearch", "WebFetch"],
  "skills": ["agent-browser", "rich-output"]
}
```

Narrower surfaces pay off twice: less noise in the agent's skill context (relevant to #50's compaction budget), and fewer capabilities to trip over on small models (the driver behind PR #73's `qwen3.5:4b` hallucinations).

## Semantics

| `skills` value | Behavior |
|---|---|
| unset (`undefined`) | Receive every global skill — **backward compatible** default |
| `[]` | Explicit opt-out; no global skills copied |
| `["status", "rich-output"]` | Only those global skills |

When an allowlist is set, previously-copied global skills not in the list are **scrubbed** on the next spawn, so shrinking an agent's allowlist actually takes effect (otherwise the old skills would linger and silently stay in context). The scrub only touches directories whose names appear in `container/skills/` — user-added or host-installed skill dirs are left alone.

## Code paths

| File | Change |
|---|---|
| `src/types.ts` | new `Agent.skills?: string[]` with backward-compat semantics |
| `src/agent-discovery.ts` | parse `config.skills` (mirrors `config.tools`, drops non-string entries); export `loadAgentFromDir` for direct testing |
| `src/container-runner.ts` | thread `skillsAllowlist` through `ContainerInput` → `buildVolumeMounts`; filter + scrub the `cpSync` loop |
| `src/index.ts` | wire `skillsAllowlist: agent?.skills` at both `ContainerInput` construction sites |
| `src/agent-discovery.test.ts` | 6 new tests for the parsing behavior |

## Test plan

- [x] 505 host tests passing (6 new + 499 existing)
- [x] `npm run build` clean
- [x] **Live smoke test** on `web_test-team`:
  - Narrowed `@greeter` to `skills: ["status"]`
  - After restart + cold spawn: greeter's `.claude/skills/` went from 7 skills to exactly `status` (plus one unknown dir `launchdarkly`, correctly left alone by the scrub)
  - Control `@analyst` (no allowlist) retained all 7
  - Greeter responded to `@greeter hello there` normally

## Relationship to other issues

- **Phase 2 (#74)** already shipped tools-side. This is the skills half, structurally the same shape.
- **#50** — narrower skill sets mean fewer skills fighting for the ~25K combined compaction budget. A natural partner to `/context-audit`.
- **#69** — capability-governance hooks will eventually feed into role-based skill defaults, same way they already feed `NON_SDK_SPECIALIST_ALLOWED_TOOLS`. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)