### PR TITLE
Side panel Phase 1: retroactive agent conversation viewer (#90)

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -54,6 +54,7 @@ import {
   getThreadMessages,
   getUsageStats,
   getLatestRunForChat,
+  getAgentRunById,
   getSession,
   getSessionPressure,
   getAllSessionPressure,
@@ -414,8 +415,13 @@ export class WebChannel implements Channel {
       durationApiMs: number;
       numTurns: number;
     },
+    runId?: number,
   ): void {
-    this.broadcast('usage_update', { jid: chatJid, ...usage });
+    this.broadcast('usage_update', {
+      jid: chatJid,
+      ...usage,
+      run_id: runId,
+    });
   }
 
   // --- HTTP Request Handler ---
@@ -1785,24 +1791,58 @@ You do not delegate. If something falls outside your role, say so plainly in you
       return this.json(res, 200, { ok: true });
     }
 
-    // GET /api/transcript?group=folder — parse the session transcript for a group
+    // GET /api/transcript?group=folder[&run_id=N] — parse the session transcript
+    // for a group, optionally scoped to a single agent_runs row's time window.
     if (method === 'GET' && url.pathname === '/api/transcript') {
       const folder = url.searchParams.get('group');
       if (!folder) return this.json(res, 400, { error: 'group required' });
 
-      const sessionId = getSession(folder);
+      const runIdParam = url.searchParams.get('run_id');
+      let runWindow: { start: number; end: number } | null = null;
+      let runSessionId: string | null = null;
+      let runMeta: {
+        id: number;
+        timestamp: string;
+        duration_ms: number;
+        cost_usd: number;
+        num_turns: number;
+        session_id?: string;
+      } | null = null;
+      if (runIdParam) {
+        const runId = parseInt(runIdParam, 10);
+        if (!Number.isFinite(runId)) {
+          return this.json(res, 400, { error: 'invalid run_id' });
+        }
+        const run = getAgentRunById(runId);
+        if (!run) {
+          return this.json(res, 404, { error: 'run not found' });
+        }
+        const end = new Date(run.timestamp).getTime();
+        const start = end - (run.duration_ms || 0);
+        // Pad by 2s on the leading edge — the SDK timestamps the `result`
+        // message when the run ends, and earlier tool_use entries may have
+        // slightly earlier clock readings than duration_ms alone captures.
+        runWindow = { start: start - 2000, end: end + 500 };
+        runSessionId = run.session_id || null;
+        runMeta = {
+          id: run.id,
+          timestamp: run.timestamp,
+          duration_ms: run.duration_ms,
+          cost_usd: run.cost_usd,
+          num_turns: run.num_turns,
+          session_id: run.session_id,
+        };
+      }
+
+      const sessionId = runSessionId || getSession(folder);
       if (!sessionId) {
         return this.json(res, 404, { error: 'No active session' });
       }
 
-      // Find transcript JSONL — try common project paths
-      const sessionsBase = path.join(
-        DATA_DIR,
-        'sessions',
-        folder,
-        '.claude',
-        'projects',
-      );
+      // Find transcript JSONL anywhere under the group's session dir. Older
+      // single-agent sessions live at `{folder}/.claude/projects/...` while
+      // multi-agent ones nest under `{folder}/{agent}/.claude/projects/...`.
+      const sessionsBase = path.join(DATA_DIR, 'sessions', folder);
       let transcriptPath: string | null = null;
       if (fs.existsSync(sessionsBase)) {
         const findJsonl = (dir: string): string | null => {
@@ -1848,7 +1888,15 @@ You do not delegate. If something falls outside your role, say so plainly in you
           timestamp?: string;
         }> = [];
 
+        const inWindow = (ts: string | undefined): boolean => {
+          if (!runWindow) return true;
+          if (!ts) return false;
+          const t = new Date(ts).getTime();
+          return t >= runWindow.start && t <= runWindow.end;
+        };
+
         for (const entry of entries) {
+          if (!inWindow(entry.timestamp)) continue;
           if (entry.type === 'assistant' && entry.message?.content) {
             for (const block of entry.message.content) {
               if (block.type === 'text' && block.text) {
@@ -1911,7 +1959,7 @@ You do not delegate. If something falls outside your role, say so plainly in you
           }
         }
 
-        return this.json(res, 200, { sessionId, timeline });
+        return this.json(res, 200, { sessionId, timeline, run: runMeta });
       } catch (err) {
         logger.error({ err, folder }, 'Failed to parse transcript');
         return this.json(res, 500, { error: 'Failed to parse transcript' });

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1895,10 +1895,58 @@ You do not delegate. If something falls outside your role, say so plainly in you
           return t >= runWindow.start && t <= runWindow.end;
         };
 
+        const extractToolSummary = (
+          input: Record<string, unknown> | undefined,
+        ): string => {
+          if (!input) return '';
+          const s = (v: unknown, n: number): string =>
+            String(v).split('\n')[0].slice(0, n);
+          if (input.command) return s(input.command, 120);
+          if (input.file_path)
+            return String(input.file_path).split(/[/\\]/).pop() ?? '';
+          if (input.pattern) return s(input.pattern, 80);
+          if (input.path) return s(input.path, 120);
+          if (input.url) return s(input.url, 120);
+          if (input.query) return s(input.query, 120);
+          return '';
+        };
+
+        const extractResultContent = (c: unknown): string => {
+          if (typeof c === 'string') return c.slice(0, 500);
+          if (Array.isArray(c)) {
+            return c
+              .filter(
+                (b: unknown): b is { type: string; text?: string } =>
+                  typeof b === 'object' &&
+                  b !== null &&
+                  (b as { type: string }).type === 'text',
+              )
+              .map((b) => b.text ?? '')
+              .join('')
+              .slice(0, 500);
+          }
+          return '';
+        };
+
+        // The orchestrator wraps inbound user text in a <messages> envelope
+        // with sender+time metadata. For display, extract the raw message
+        // body from the innermost <message> tag when present.
+        const unwrapUserText = (raw: string): string => {
+          // Require whitespace after `message` so we don't also match `<messages>`.
+          const match = raw.match(
+            /<message\s[^>]*>([\s\S]*?)<\/message>\s*<\/messages>/i,
+          );
+          return (match?.[1] ?? raw).trim();
+        };
+
         for (const entry of entries) {
           if (!inWindow(entry.timestamp)) continue;
-          if (entry.type === 'assistant' && entry.message?.content) {
-            for (const block of entry.message.content) {
+
+          const content = entry.message?.content;
+          if (!content) continue;
+
+          if (entry.type === 'assistant' && Array.isArray(content)) {
+            for (const block of content) {
               if (block.type === 'text' && block.text) {
                 timeline.push({
                   type: 'text',
@@ -1908,53 +1956,55 @@ You do not delegate. If something falls outside your role, say so plainly in you
                 });
               }
               if (block.type === 'tool_use') {
-                const summary = block.input?.command
-                  ? String(block.input.command).split('\n')[0].slice(0, 120)
-                  : block.input?.file_path
-                    ? String(block.input.file_path).split(/[/\\]/).pop()
-                    : block.input?.pattern
-                      ? String(block.input.pattern).slice(0, 80)
-                      : '';
                 timeline.push({
                   type: 'tool_use',
                   tool: block.name,
-                  summary,
-                  timestamp: entry.timestamp,
-                });
-              }
-              if (block.type === 'tool_result') {
-                timeline.push({
-                  type: 'tool_result',
-                  tool: block.name,
-                  content:
-                    typeof block.content === 'string'
-                      ? block.content.slice(0, 500)
-                      : '',
+                  summary: extractToolSummary(block.input),
                   timestamp: entry.timestamp,
                 });
               }
             }
           }
-          if (entry.type === 'user' && entry.message?.content) {
-            const text =
-              typeof entry.message.content === 'string'
-                ? entry.message.content
-                : Array.isArray(entry.message.content)
-                  ? entry.message.content
-                      .filter(
-                        (b: { type: string; text?: string }) =>
-                          b.type === 'text',
-                      )
-                      .map((b: { text: string }) => b.text)
-                      .join('')
-                  : '';
-            if (text) {
-              timeline.push({
-                type: 'text',
-                role: 'user',
-                content: text.slice(0, 2000),
-                timestamp: entry.timestamp,
-              });
+
+          if (entry.type === 'user') {
+            if (typeof content === 'string') {
+              const text = unwrapUserText(content);
+              if (text) {
+                timeline.push({
+                  type: 'text',
+                  role: 'user',
+                  content: text.slice(0, 2000),
+                  timestamp: entry.timestamp,
+                });
+              }
+            } else if (Array.isArray(content)) {
+              // User messages can carry either plain text (a real user turn)
+              // or tool_result blocks (the agent's tool chain). Surface both.
+              const textParts: string[] = [];
+              for (const block of content) {
+                if (block.type === 'text' && block.text) {
+                  textParts.push(block.text);
+                }
+                if (block.type === 'tool_result') {
+                  timeline.push({
+                    type: 'tool_result',
+                    tool: block.name,
+                    content: extractResultContent(block.content),
+                    timestamp: entry.timestamp,
+                  });
+                }
+              }
+              if (textParts.length) {
+                const text = unwrapUserText(textParts.join(''));
+                if (text) {
+                  timeline.push({
+                    type: 'text',
+                    role: 'user',
+                    content: text.slice(0, 2000),
+                    timestamp: entry.timestamp,
+                  });
+                }
+              }
             }
           }
         }

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1939,6 +1939,10 @@ You do not delegate. If something falls outside your role, say so plainly in you
           return (match?.[1] ?? raw).trim();
         };
 
+        // Track tool_use.id → tool name so we can label tool_result entries,
+        // which only carry a tool_use_id (not the tool name).
+        const toolNameById = new Map<string, string>();
+
         for (const entry of entries) {
           if (!inWindow(entry.timestamp)) continue;
 
@@ -1947,6 +1951,13 @@ You do not delegate. If something falls outside your role, say so plainly in you
 
           if (entry.type === 'assistant' && Array.isArray(content)) {
             for (const block of content) {
+              if (block.type === 'thinking' && block.thinking) {
+                timeline.push({
+                  type: 'thinking',
+                  content: block.thinking.slice(0, 2000),
+                  timestamp: entry.timestamp,
+                });
+              }
               if (block.type === 'text' && block.text) {
                 timeline.push({
                   type: 'text',
@@ -1956,6 +1967,9 @@ You do not delegate. If something falls outside your role, say so plainly in you
                 });
               }
               if (block.type === 'tool_use') {
+                if (block.id && block.name) {
+                  toolNameById.set(block.id, block.name);
+                }
                 timeline.push({
                   type: 'tool_use',
                   tool: block.name,
@@ -1969,7 +1983,9 @@ You do not delegate. If something falls outside your role, say so plainly in you
           if (entry.type === 'user') {
             if (typeof content === 'string') {
               const text = unwrapUserText(content);
-              if (text) {
+              // SDK harness reminders ("[system] You completed tool calls
+              // but did not send a visible reply...") are not user turns.
+              if (text && !text.startsWith('[system]')) {
                 timeline.push({
                   type: 'text',
                   role: 'user',
@@ -1988,7 +2004,11 @@ You do not delegate. If something falls outside your role, say so plainly in you
                 if (block.type === 'tool_result') {
                   timeline.push({
                     type: 'tool_result',
-                    tool: block.name,
+                    tool:
+                      (block.tool_use_id &&
+                        toolNameById.get(block.tool_use_id)) ||
+                      block.name ||
+                      '',
                     content: extractResultContent(block.content),
                     timestamp: entry.timestamp,
                   });
@@ -1996,7 +2016,7 @@ You do not delegate. If something falls outside your role, say so plainly in you
               }
               if (textParts.length) {
                 const text = unwrapUserText(textParts.join(''));
-                if (text) {
+                if (text && !text.startsWith('[system]')) {
                   timeline.push({
                     type: 'text',
                     role: 'user',

--- a/src/db.ts
+++ b/src/db.ts
@@ -207,6 +207,37 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* column already exists */
   }
+
+  // One-shot backfill: link pre-existing bot messages to their agent_runs row
+  // by emulating what attachUsageToLastBotMessage does live — for each run in
+  // chronological order, claim the most recent orphan bot message in the same
+  // chat whose timestamp is ≤ the run's timestamp.
+  const backfillDone = database
+    .prepare(`SELECT value FROM router_state WHERE key = ?`)
+    .get('migrated_run_id_backfill') as { value: string } | undefined;
+  if (!backfillDone) {
+    const runs = database
+      .prepare(
+        `SELECT rowid AS id, chat_jid, timestamp FROM agent_runs ORDER BY timestamp ASC`,
+      )
+      .all() as Array<{ id: number; chat_jid: string; timestamp: string }>;
+    const claim = database.prepare(`
+      UPDATE messages SET run_id = ?
+      WHERE rowid = (
+        SELECT rowid FROM messages
+        WHERE chat_jid = ? AND is_bot_message = 1 AND run_id IS NULL
+          AND timestamp <= ?
+        ORDER BY timestamp DESC LIMIT 1
+      )
+    `);
+    const tx = database.transaction((rows: typeof runs) => {
+      for (const r of rows) claim.run(r.id, r.chat_jid, r.timestamp);
+    });
+    tx(runs);
+    database
+      .prepare(`INSERT OR REPLACE INTO router_state (key, value) VALUES (?, ?)`)
+      .run('migrated_run_id_backfill', new Date().toISOString());
+  }
   database.exec(`
     CREATE TABLE IF NOT EXISTS threads (
       thread_id TEXT PRIMARY KEY,

--- a/src/db.ts
+++ b/src/db.ts
@@ -196,6 +196,17 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* column already exists */
   }
+
+  // Add run_id column to messages (Phase 1 side panel: correlates a rendered
+  // bot message back to the agent_runs row that produced it).
+  try {
+    database.exec(`ALTER TABLE messages ADD COLUMN run_id INTEGER`);
+    database.exec(
+      `CREATE INDEX IF NOT EXISTS idx_messages_run_id ON messages(run_id)`,
+    );
+  } catch {
+    /* column already exists */
+  }
   database.exec(`
     CREATE TABLE IF NOT EXISTS threads (
       thread_id TEXT PRIMARY KEY,
@@ -537,7 +548,7 @@ export function getMessagesSince(
   const threadFilter = excludeThreaded ? 'AND thread_id IS NULL' : '';
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, thread_id, usage
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, thread_id, usage, run_id
       FROM messages
       WHERE chat_jid = ? AND timestamp > ?
         ${botFilter}
@@ -1289,43 +1300,58 @@ export interface AgentRunRecord {
 }
 
 /**
- * Attach usage JSON to the most recent bot message in a chat.
+ * Attach usage JSON (and optionally run_id) to the most recent bot message in a chat.
  * Called after storeAgentRun so the usage survives page refreshes.
  */
 export function attachUsageToLastBotMessage(
   chatJid: string,
   usageJson: string,
+  runId?: number,
 ): void {
-  db.prepare(
-    `UPDATE messages SET usage = ?
-     WHERE rowid = (
-       SELECT rowid FROM messages
-       WHERE chat_jid = ? AND is_bot_message = 1
-       ORDER BY timestamp DESC LIMIT 1
-     )`,
-  ).run(usageJson, chatJid);
+  if (runId !== undefined) {
+    db.prepare(
+      `UPDATE messages SET usage = ?, run_id = ?
+       WHERE rowid = (
+         SELECT rowid FROM messages
+         WHERE chat_jid = ? AND is_bot_message = 1
+         ORDER BY timestamp DESC LIMIT 1
+       )`,
+    ).run(usageJson, runId, chatJid);
+  } else {
+    db.prepare(
+      `UPDATE messages SET usage = ?
+       WHERE rowid = (
+         SELECT rowid FROM messages
+         WHERE chat_jid = ? AND is_bot_message = 1
+         ORDER BY timestamp DESC LIMIT 1
+       )`,
+    ).run(usageJson, chatJid);
+  }
 }
 
-export function storeAgentRun(run: AgentRunRecord): void {
-  db.prepare(
-    `INSERT INTO agent_runs (chat_jid, group_folder, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cost_usd, duration_ms, num_turns, is_error, tool_history, container_reuse)
+export function storeAgentRun(run: AgentRunRecord): number {
+  const result = db
+    .prepare(
+      `INSERT INTO agent_runs (chat_jid, group_folder, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cost_usd, duration_ms, num_turns, is_error, tool_history, container_reuse)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    run.chat_jid,
-    run.group_folder,
-    run.session_id || null,
-    run.timestamp,
-    run.input_tokens,
-    run.output_tokens,
-    run.cache_read_tokens,
-    run.cache_write_tokens,
-    run.cost_usd,
-    run.duration_ms,
-    run.num_turns,
-    run.is_error ? 1 : 0,
-    run.tool_history || null,
-    run.container_reuse || 'cold_start',
-  );
+    )
+    .run(
+      run.chat_jid,
+      run.group_folder,
+      run.session_id || null,
+      run.timestamp,
+      run.input_tokens,
+      run.output_tokens,
+      run.cache_read_tokens,
+      run.cache_write_tokens,
+      run.cost_usd,
+      run.duration_ms,
+      run.num_turns,
+      run.is_error ? 1 : 0,
+      run.tool_history || null,
+      run.container_reuse || 'cold_start',
+    );
+  return Number(result.lastInsertRowid);
 }
 
 export function getUsageStats(periodHours: number = 24): {
@@ -1522,6 +1548,24 @@ export function getLatestRunForChat(chatJid: string): AgentRunRecord | null {
     )
     .get(chatJid) as
     | (Omit<AgentRunRecord, 'is_error'> & { is_error: number })
+    | undefined;
+  if (!row) return null;
+  return { ...row, is_error: row.is_error === 1 };
+}
+
+export interface AgentRunRow extends AgentRunRecord {
+  id: number;
+}
+
+/**
+ * Get a single agent_runs row by rowid. Used by the side panel to slice the
+ * transcript JSONL to a specific run's timestamp window.
+ */
+export function getAgentRunById(runId: number): AgentRunRow | null {
+  const row = db
+    .prepare('SELECT rowid as id, * FROM agent_runs WHERE rowid = ?')
+    .get(runId) as
+    | (Omit<AgentRunRow, 'is_error'> & { is_error: number })
     | undefined;
   if (!row) return null;
   return { ...row, is_error: row.is_error === 1 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,10 +166,14 @@ const pendingOrigins: Record<string, { originJid: string; threadId?: string }> =
   {};
 
 /** Broadcast usage metrics to web UI clients */
-function broadcastUsage(chatJid: string, usage: UsageData): void {
+function broadcastUsage(
+  chatJid: string,
+  usage: UsageData,
+  runId?: number,
+): void {
   for (const ch of channels) {
     if (ch.name === 'web' && 'broadcastUsageUpdate' in ch) {
-      (ch as any).broadcastUsageUpdate(chatJid, usage);
+      (ch as any).broadcastUsageUpdate(chatJid, usage, runId);
       break;
     }
   }
@@ -1790,7 +1794,7 @@ async function runAgent(
         // so onOutput fires once per user message, not once per container)
         if (output.usage && output.usage.numTurns > 0) {
           const u = output.usage;
-          storeAgentRun({
+          const runId = storeAgentRun({
             chat_jid: chatJid,
             group_folder: group.folder,
             session_id: sessions[agentId],
@@ -1813,8 +1817,9 @@ async function runAgent(
               ...u,
               toolHistory: toolHistory.length > 0 ? toolHistory : undefined,
             }),
+            runId,
           );
-          broadcastUsage(chatJid, u);
+          broadcastUsage(chatJid, u, runId);
           const cacheHitRatio =
             u.cacheReadTokens /
             Math.max(1, u.cacheReadTokens + u.cacheWriteTokens);
@@ -1894,7 +1899,7 @@ async function runAgent(
 
     if (output.usage && output.usage.numTurns > 0) {
       const u = output.usage;
-      storeAgentRun({
+      const runId = storeAgentRun({
         chat_jid: chatJid,
         group_folder: group.folder,
         session_id: sessions[agentId],
@@ -1917,8 +1922,9 @@ async function runAgent(
           ...u,
           toolHistory: toolHistory.length > 0 ? toolHistory : undefined,
         }),
+        runId,
       );
-      broadcastUsage(chatJid, u);
+      broadcastUsage(chatJid, u, runId);
       const cacheHitRatio =
         u.cacheReadTokens / Math.max(1, u.cacheReadTokens + u.cacheWriteTokens);
       logger.info(

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface NewMessage {
   is_bot_message?: boolean;
   thread_id?: string;
   usage?: string;
+  run_id?: number | null;
 }
 
 export interface MediaArtifact {

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -134,6 +134,9 @@ export const deleteGroupAgent = (folder, agentName) =>
   fetchJson(`/api/groups/${encodeURIComponent(folder)}/agents/${encodeURIComponent(agentName)}`, { method: 'DELETE' });
 export const getOllamaModels = () => fetchJson('/api/ollama/models');
 export const getTools = () => fetchJson('/api/tools');
-export const getTranscript = (groupFolder) => fetchJson(`/api/transcript?group=${encodeURIComponent(groupFolder)}`);
+export const getTranscript = (groupFolder, runId) => {
+  const qs = runId != null ? `&run_id=${encodeURIComponent(runId)}` : '';
+  return fetchJson(`/api/transcript?group=${encodeURIComponent(groupFolder)}${qs}`);
+};
 export const getAchievements = () => fetchJson('/api/achievements');
 export const getSessionPressure = () => fetchJson('/api/session/pressure');

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -76,6 +76,9 @@ function loadNotifLastRead() {
 export const notifications = signal(loadNotifHistory());
 export const notifLastReadAt = signal(loadNotifLastRead());
 export const flashMessageId = signal(null);
+// Side panel: { runId, groupFolder, usage? } when open, null when closed.
+// Phase 1 of side panels (issue #90) — retroactive agent session viewer.
+export const agentPanel = signal(null);
 export const unreadNotifCount = computed(() => {
   const lastRead = notifLastReadAt.value;
   return notifications.value.filter(
@@ -326,6 +329,7 @@ api.onSSE('usage_update', (data) => {
           ...msgs[i],
           usage: data,
           toolHistory: progressData?.history || [],
+          runId: data.run_id ?? msgs[i].runId ?? null,
         };
         messages.value = msgs;
         break;
@@ -562,6 +566,7 @@ export async function selectGroup(jid) {
       senderName: m.sender_name,
       usage: parsedUsage,
       toolHistory: parsedUsage?.toolHistory || [],
+      runId: m.run_id ?? null,
     };
   });
   const dbIds = new Set(dbMessages.map((m) => m.id));

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -28,7 +28,31 @@ function formatCost(usd) {
   return `$${usd.toFixed(2)}`;
 }
 
+function ThinkingEntry({ entry }) {
+  const [open, setOpen] = useState(false);
+  return html`
+    <div class="py-1 px-2 border-l-2 border-txt-muted/30 opacity-70">
+      <button
+        class="text-[10px] text-txt-muted font-mono hover:text-txt-2 transition-colors flex items-center gap-1.5 cursor-pointer"
+        onClick=${() => setOpen(!open)}
+        title="Agent internal reasoning"
+      >
+        <span class="text-[9px] transition-transform ${open ? 'rotate-90' : ''}">\u25B6</span>
+        <span>thinking</span>
+      </button>
+      ${open && html`
+        <div class="mt-1 text-[11px] text-txt-muted italic whitespace-pre-wrap break-words">
+          ${entry.content}
+        </div>
+      `}
+    </div>
+  `;
+}
+
 function Entry({ entry }) {
+  if (entry.type === 'thinking') {
+    return html`<${ThinkingEntry} entry=${entry} />`;
+  }
   if (entry.type === 'text') {
     const isUser = entry.role === 'user';
     return html`

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact';
 import { useEffect, useState } from 'preact/hooks';
-import { agentPanel, selectedGroup } from '../app.js';
+import { agentPanel } from '../app.js';
 import * as api from '../api.js';
 
 function formatTime(ts) {
@@ -44,14 +44,14 @@ function Entry({ entry }) {
     return html`
       <div class="flex items-start gap-2 py-1.5 px-2 border-l-2 border-accent/50">
         <span class="font-mono text-[10px] text-accent shrink-0 mt-0.5">${entry.tool}</span>
-        <span class="text-xs text-txt-2 truncate">${entry.summary || ''}</span>
+        <span class="text-xs text-txt-2 font-mono break-words">${entry.summary || ''}</span>
       </div>
     `;
   }
   if (entry.type === 'tool_result') {
     if (!entry.content) return null;
     return html`
-      <div class="pl-4 text-[11px] text-txt-muted font-mono whitespace-pre-wrap break-words line-clamp-3">
+      <div class="pl-4 text-[11px] text-txt-muted font-mono whitespace-pre-wrap break-words max-h-32 overflow-y-auto">
         ${entry.content}
       </div>
     `;
@@ -89,6 +89,15 @@ export function AgentPanel() {
       });
     return () => { cancelled = true; };
   }, [state?.runId, state?.groupFolder]);
+
+  useEffect(() => {
+    if (!state) return;
+    const onKey = (e) => {
+      if (e.key === 'Escape') agentPanel.value = null;
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [state]);
 
   if (!state) return null;
 

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -1,0 +1,153 @@
+import { html } from 'htm/preact';
+import { useEffect, useState } from 'preact/hooks';
+import { agentPanel, selectedGroup } from '../app.js';
+import * as api from '../api.js';
+
+function formatTime(ts) {
+  if (!ts) return '';
+  try {
+    return new Date(ts).toLocaleTimeString();
+  } catch {
+    return '';
+  }
+}
+
+function formatDuration(ms) {
+  if (!ms) return '';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
+
+function formatCost(usd) {
+  if (!usd) return '';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function Entry({ entry }) {
+  if (entry.type === 'text') {
+    const isUser = entry.role === 'user';
+    return html`
+      <div class="flex flex-col gap-1 py-2 px-3 rounded-md ${isUser ? 'bg-userbg' : 'bg-asstbg'}">
+        <div class="text-[10px] text-txt-muted font-mono">
+          ${isUser ? 'user' : 'assistant'} · ${formatTime(entry.timestamp)}
+        </div>
+        <div class="text-xs text-txt-2 whitespace-pre-wrap break-words">${entry.content}</div>
+      </div>
+    `;
+  }
+  if (entry.type === 'tool_use') {
+    return html`
+      <div class="flex items-start gap-2 py-1.5 px-2 border-l-2 border-accent/50">
+        <span class="font-mono text-[10px] text-accent shrink-0 mt-0.5">${entry.tool}</span>
+        <span class="text-xs text-txt-2 truncate">${entry.summary || ''}</span>
+      </div>
+    `;
+  }
+  if (entry.type === 'tool_result') {
+    if (!entry.content) return null;
+    return html`
+      <div class="pl-4 text-[11px] text-txt-muted font-mono whitespace-pre-wrap break-words line-clamp-3">
+        ${entry.content}
+      </div>
+    `;
+  }
+  return null;
+}
+
+export function AgentPanel() {
+  const state = agentPanel.value;
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!state) {
+      setData(null);
+      setError(null);
+      return;
+    }
+    const { runId, groupFolder } = state;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .getTranscript(groupFolder, runId)
+      .then((resp) => {
+        if (cancelled) return;
+        setData(resp);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.message || 'Failed to load transcript');
+        setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [state?.runId, state?.groupFolder]);
+
+  if (!state) return null;
+
+  const run = data?.run;
+  const timeline = data?.timeline || [];
+
+  function close() {
+    agentPanel.value = null;
+  }
+
+  return html`
+    <div
+      class="fixed inset-0 z-40 bg-black/40"
+      onClick=${close}
+    />
+    <aside
+      class="fixed top-0 right-0 h-full w-full md:w-[440px] lg:w-[520px] z-50 bg-bg-2 border-l border-border shadow-xl flex flex-col"
+    >
+      <header class="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div class="flex flex-col gap-0.5 min-w-0">
+          <h3 class="text-sm font-semibold truncate">Agent conversation</h3>
+          ${run && html`
+            <div class="text-[11px] text-txt-muted font-mono truncate">
+              ${formatTime(run.timestamp)}
+              ${run.duration_ms ? ` · ${formatDuration(run.duration_ms)}` : ''}
+              ${run.num_turns ? ` · ${run.num_turns} turn${run.num_turns !== 1 ? 's' : ''}` : ''}
+              ${run.cost_usd ? ` · ${formatCost(run.cost_usd)}` : ''}
+            </div>
+          `}
+        </div>
+        <button
+          class="w-7 h-7 flex items-center justify-center rounded-md text-txt-2 hover:bg-bg-hover hover:text-txt transition-colors shrink-0 ml-2"
+          title="Close"
+          onClick=${close}
+        >
+          <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+          </svg>
+        </button>
+      </header>
+      <div class="flex-1 overflow-y-auto p-3 flex flex-col gap-1.5">
+        ${loading && html`<div class="text-xs text-txt-muted p-4 text-center">Loading transcript...</div>`}
+        ${error && html`
+          <div class="text-xs text-err p-4 text-center">
+            ${error}
+            ${state.runId == null && html`
+              <div class="text-txt-muted mt-2">No run ID recorded for this message. Older messages may not have this data.</div>
+            `}
+          </div>
+        `}
+        ${!loading && !error && timeline.length === 0 && html`
+          <div class="text-xs text-txt-muted p-4 text-center">No transcript entries in this run window.</div>
+        `}
+        ${timeline.map((entry, i) => html`<${Entry} key=${i} entry=${entry} />`)}
+      </div>
+    </aside>
+  `;
+}
+
+export function openAgentPanel(runId, groupFolder) {
+  agentPanel.value = { runId, groupFolder };
+}

--- a/web/js/components/App.js
+++ b/web/js/components/App.js
@@ -8,6 +8,7 @@ import { NewGroupDialog } from './NewGroupDialog.js';
 import { AchievementToast } from './blocks/AchievementToast.js';
 import { AchievementPanel } from './AchievementPanel.js';
 import { CredentialModal } from './CredentialModal.js';
+import { AgentPanel } from './AgentPanel.js';
 
 export function App() {
   const group = selectedGroup.value;
@@ -40,6 +41,7 @@ export function App() {
       <${AchievementToast} />
       <${AchievementPanel} />
       <${CredentialModal} />
+      <${AgentPanel} />
     </div>
   `;
 }

--- a/web/js/components/Message.js
+++ b/web/js/components/Message.js
@@ -4,6 +4,7 @@ import { parseBlocks } from '../block-parser.js';
 import { BlockRenderer } from './blocks/BlockRenderer.js';
 import { md } from '../markdown.js';
 import { selectedGroup } from '../app.js';
+import { openAgentPanel } from './AgentPanel.js';
 
 // Consistent color for each agent name (hash → HSL hue)
 const AGENT_COLORS = {};
@@ -48,7 +49,7 @@ function renderToolLabel(tool) {
   return tool || '>';
 }
 
-function UsageFooter({ usage, toolHistory, expanded, onToggle }) {
+function UsageFooter({ usage, toolHistory, expanded, onToggle, runId, groupFolder }) {
   if (!usage || (!usage.numTurns && !usage.durationMs)) return null;
 
   const parts = [];
@@ -59,20 +60,32 @@ function UsageFooter({ usage, toolHistory, expanded, onToggle }) {
   if (usage.costUsd) parts.push(formatCost(usage.costUsd));
 
   const hasHistory = toolHistory && toolHistory.length > 0;
+  const canViewConversation = runId != null && groupFolder;
 
   return html`
     <div class="mt-1">
-      <div
-        class="flex items-center gap-1.5 text-[10px] text-txt-muted font-mono ${hasHistory ? 'cursor-pointer hover:text-txt-2' : ''}"
-        onClick=${hasHistory ? onToggle : undefined}
-      >
-        ${hasHistory && html`
-          <span class="text-[9px] transition-transform ${expanded ? 'rotate-90' : ''}">\u25B6</span>
+      <div class="flex items-center gap-2 flex-wrap">
+        <div
+          class="flex items-center gap-1.5 text-[10px] text-txt-muted font-mono ${hasHistory ? 'cursor-pointer hover:text-txt-2' : ''}"
+          onClick=${hasHistory ? onToggle : undefined}
+        >
+          ${hasHistory && html`
+            <span class="text-[9px] transition-transform ${expanded ? 'rotate-90' : ''}">\u25B6</span>
+          `}
+          ${parts.map((p, i) => html`
+            ${i > 0 && html`<span class="opacity-40">\u00B7</span>`}
+            <span>${p}</span>
+          `)}
+        </div>
+        ${canViewConversation && html`
+          <button
+            class="text-[10px] text-txt-muted hover:text-accent transition-colors font-mono cursor-pointer"
+            onClick=${(e) => { e.stopPropagation(); openAgentPanel(runId, groupFolder); }}
+            title="Open the agent's full tool call chain in a side panel"
+          >
+            view conversation \u2192
+          </button>
         `}
-        ${parts.map((p, i) => html`
-          ${i > 0 && html`<span class="opacity-40">\u00B7</span>`}
-          <span>${p}</span>
-        `)}
       </div>
       ${expanded && hasHistory && html`
         <div class="mt-1.5 pl-3 border-l-2 border-border flex flex-col gap-0.5">
@@ -88,7 +101,7 @@ function UsageFooter({ usage, toolHistory, expanded, onToggle }) {
   `;
 }
 
-export function Message({ role, content, timestamp, senderName, isError, compact, usage, toolHistory }) {
+export function Message({ role, content, timestamp, senderName, isError, compact, usage, toolHistory, runId }) {
   const isAssistant = role === 'assistant';
   const time = timestamp
     ? new Date(timestamp).toLocaleTimeString()
@@ -130,6 +143,8 @@ export function Message({ role, content, timestamp, senderName, isError, compact
           toolHistory=${toolHistory}
           expanded=${expanded}
           onToggle=${() => setExpanded(!expanded)}
+          runId=${runId}
+          groupFolder=${group?.folder}
         />
       `}
     </div>

--- a/web/js/components/MessageList.js
+++ b/web/js/components/MessageList.js
@@ -118,6 +118,7 @@ export function MessageList() {
                     isError=${m.isError}
                     usage=${m.usage}
                     toolHistory=${m.toolHistory}
+                    runId=${m.runId}
                   />
                   ${thread && html`
                     <${ThreadView}


### PR DESCRIPTION
## Summary

First cut of the side panel work from #90. Retroactive only — click "view conversation →" on a bot message to open a right-side drawer showing that run's tool chain, reasoning, and outputs. No orchestrator routing changes, no schema beyond a single `run_id` column.

- **`run_id` correlation**: `messages.run_id` migration, `storeAgentRun()` returns the inserted rowid, threaded through `attachUsageToLastBotMessage()` and the `usage_update` SSE payload so fresh bot messages link without a refresh
- **Scoped transcript API**: `/api/transcript?run_id=X` slices the session JSONL by the run's `[timestamp - duration_ms, timestamp]` window and returns `{ sessionId, timeline, run }`
- **Timeline content**: text, tool_use (with summary), tool_result (with tool name resolved via a `tool_use_id → name` map), and thinking blocks. User text is unwrapped from the orchestrator's `<messages>` envelope; `[system]` SDK harness reminders are filtered
- **UI**: new `AgentPanel` component — fixed right drawer, Esc/backdrop/X to close, header shows run duration/turns/cost, thinking blocks render collapsed
- **Historical coverage**: one-shot backfill walks `agent_runs` chronologically and claims the most recent orphan bot message per chat within each run's window (mirrors what `attachUsageToLastBotMessage` does live). On my instance: 3/424 → 332/424 bot messages now have `run_id`. Unmatched ones predate the `agent_runs` table

## Out of scope (intentional)

- **Live streaming into the panel** — Phase 1 as originally scoped included this, but it folds more naturally into Phase 2 where `thread_id` / portal routing opens the panel proactively during a run. Deferred to avoid building it twice.
- **Phase 2 portal routing** (`target: "thread"` action buttons, `thread_id` on messages, orchestrator drain). Not touched here.
- **Backfilling older messages that lack a matching `agent_runs` row**. 22% of bot messages on my instance predate the table — the "view conversation" affordance simply doesn't appear on those.

## Pre-existing bugs fixed along the way

- `/api/transcript` search path started at `{folder}/.claude/projects/`, missing multi-agent sessions that live under `{folder}/{agent}/.claude/projects/`. Widened to `{folder}`.
- `tool_result` blocks were scanned under `assistant` entries in the JSONL parser, but the SDK emits them under `user` entries — tool results never appeared at all.
- A regex intended to strip the `<messages>` wrapper matched `<messages>` itself because `<message[^>]*>` greedily ate the trailing `s`. Scoped to `<message\s[^>]*>`.

## Test plan

- [x] Unit tests pass (499/499)
- [x] `npm run build` clean
- [x] Smoke: send a message via `/api/send`, bot response carries `run_id`, `/api/transcript?run_id=X` returns a windowed timeline
- [x] Smoke: historical run (#496, 4 turns) returns full timeline with thinking, tool_use, tool_result w/ name, unwrapped user text
- [ ] Browser: click "view conversation" on a current bot message, verify panel opens, timeline renders, Esc closes
- [ ] Browser: click on a backfilled historical message, verify affordance appears and transcript loads
- [ ] Browser: verify responsive behavior (mobile full-width, desktop 440–520px drawer)

## Commits

- `aca50c7` Phase 1 foundation: schema, API, component
- `8f3a7a4` tool_result + Esc + unwrap fix
- `333b9cb` Backfill + polish (thinking, tool name, [system] filter)

Closes part of #90. Phase 2 (portal routing + action button `target`) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)