### PR TITLE
Phase 2a: Delegation portals (side-panel drawer) (#90)

### DIFF
--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -205,6 +205,7 @@ export function buildMultiAgentContext(
 
       lines.push(
         `You are the coordinator. You handle general questions directly and delegate specialist work.`,
+        `Delegation output lands in a side-panel portal — not the main chat. You see each specialist's reply in your own prompt context on your next turn, but the user does NOT see it directly unless they open the portal. Synthesize what specialists said into your own reply to the user; do not say "see above" or assume they read the specialist output.`,
         `For meaningful ongoing work, keep sidebar presence current: use mcp__nanoclaw__set_subtitle for the team-level summary, and use mcp__nanoclaw__set_agent_status for your own row if you have one.`,
         `Set concise, high-signal statuses when work starts ("Reviewing PRs", "Waiting on Scout") and clear them when the work is done.`,
         `To delegate, use the mcp__nanoclaw__delegate_to_agent tool. Valid targets and example invocations:`,
@@ -240,6 +241,7 @@ export function buildMultiAgentContext(
     if (profile.receivesMcpTools) {
       lines.push(
         `You are a specialist. Focus on your role and respond directly.`,
+        `Your reply appears in a side-panel portal the user can watch, and the coordinator reads it in their own context to synthesize the user-facing answer. Write clean, scannable prose the coordinator can quote or compress. Rich UI blocks (action buttons, forms) are not supported in portals yet — stick to text and markdown.`,
         `For meaningful ongoing work, set your own sidebar status with mcp__nanoclaw__set_agent_status using a short phrase like "Reviewing flags" or "Drafting summary", then clear it when you are done.`,
         `If work falls outside your expertise, say so in your response — the coordinator will handle routing.`,
         `Your response may be superseded for user delivery if newer context arrives first. Complete the assigned work cleanly anyway; the coordinator will still see that you finished.`,
@@ -254,7 +256,7 @@ export function buildMultiAgentContext(
       // message via the host's text-path fallback. No MCP tools, no status.
       lines.push(
         `You are a specialist. Focus on your role and respond directly.`,
-        `Respond in plain text — your entire reply will be delivered to the user as your message. You do not have tools or status controls, so keep the response self-contained.`,
+        `Respond in plain text or markdown — your reply appears in a side-panel portal and the coordinator reads it to synthesize the user-facing answer. No rich UI blocks. No tools. Keep the response self-contained.`,
         `If a request falls outside your expertise, say so briefly; the coordinator will handle routing.`,
         `Do not try to act as other agents or delegate work yourself.`,
       );

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -66,6 +66,14 @@ export interface ChannelOpts {
     threadId: string,
     agentName: string,
   ) => void;
+  /** Broadcast portal (side-drawer) thread opening */
+  onThreadOpened?: (
+    originJid: string,
+    threadId: string,
+    agentName: string,
+    kind: 'portal',
+    sourceAgent?: string,
+  ) => void;
   /** Reset session for a group (clears SDK session, evicts warm pool) */
   onResetSession?: (groupFolder: string) => Promise<void>;
   /** Get fully discovered agents for a group with runtime metadata */

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -74,6 +74,8 @@ export interface ChannelOpts {
     kind: 'portal',
     sourceAgent?: string,
   ) => void;
+  /** Broadcast portal thread completion */
+  onThreadClosed?: (originJid: string, threadId: string) => void;
   /** Reset session for a group (clears SDK session, evicts warm pool) */
   onResetSession?: (groupFolder: string) => Promise<void>;
   /** Get fully discovered agents for a group with runtime metadata */

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -51,6 +51,7 @@ import {
   deleteTask,
   getTelemetryStats,
   getThreadsForChat,
+  getPortalThreadsForChat,
   getThreadMessages,
   getUsageStats,
   getLatestRunForChat,
@@ -129,6 +130,14 @@ export class WebChannel implements Channel {
         agent_name: agentName,
         kind,
         source_agent: sourceAgent,
+      });
+    };
+    // Portal thread completion — client clears the `live` flag so the
+    // portal drops out of the drawer's live stack.
+    opts.onThreadClosed = (originJid, threadId) => {
+      this.broadcast('thread_closed', {
+        jid: originJid,
+        thread_id: threadId,
       });
     };
   }
@@ -1552,6 +1561,16 @@ You do not delegate. If something falls outside your role, say so plainly in you
     if (method === 'GET' && threadsMatch) {
       const jid = decodeURIComponent(threadsMatch[1]);
       const threads = getThreadsForChat(jid);
+      return this.json(res, 200, { threads });
+    }
+
+    // GET /api/portal-threads/:jid — portal (side-drawer) threads for a chat
+    const portalThreadsMatch = url.pathname.match(
+      /^\/api\/portal-threads\/(.+)$/,
+    );
+    if (method === 'GET' && portalThreadsMatch) {
+      const jid = decodeURIComponent(portalThreadsMatch[1]);
+      const threads = getPortalThreadsForChat(jid);
       return this.json(res, 200, { threads });
     }
 

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -114,6 +114,23 @@ export class WebChannel implements Channel {
         agent_name: agentName,
       });
     };
+    // Portal (side-drawer) thread opening — distinct event so the client
+    // can auto-open the drawer instead of rendering inline like trigger threads.
+    opts.onThreadOpened = (
+      originJid,
+      threadId,
+      agentName,
+      kind,
+      sourceAgent,
+    ) => {
+      this.broadcast('thread_opened', {
+        jid: originJid,
+        thread_id: threadId,
+        agent_name: agentName,
+        kind,
+        source_agent: sourceAgent,
+      });
+    };
   }
 
   async connect(): Promise<void> {
@@ -390,12 +407,14 @@ export class WebChannel implements Channel {
   broadcastAgentProgress(
     chatJid: string,
     event: { tool?: string; summary: string; timestamp: string },
+    threadId?: string,
   ): void {
     const agentName = getActiveAgentName(chatJid);
     this.broadcast('agent_progress', {
       jid: chatJid,
       ...event,
       agent_name: agentName,
+      thread_id: threadId,
     });
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -249,6 +249,17 @@ function createSchema(database: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id);
   `);
 
+  // Add kind column to threads (Phase 2 side panel: distinguishes inline
+  // trigger threads from side-drawer portal threads). 'trigger' = existing
+  // web-all trigger reply chains (rendered inline by ThreadView), 'portal'
+  // = delegation/action-button/agent-initiated side work (rendered in the
+  // AgentPanel drawer).
+  try {
+    database.exec(`ALTER TABLE threads ADD COLUMN kind TEXT DEFAULT 'trigger'`);
+  } catch {
+    /* column already exists */
+  }
+
   database.exec(`
     CREATE TABLE IF NOT EXISTS media_artifacts (
       id TEXT PRIMARY KEY,
@@ -615,15 +626,17 @@ export function createThread(
   agentJid: string,
   originJid: string,
   agentName?: string,
+  kind: 'trigger' | 'portal' = 'trigger',
 ): void {
   db.prepare(
-    `INSERT OR IGNORE INTO threads (thread_id, agent_jid, origin_jid, agent_name, created_at) VALUES (?, ?, ?, ?, ?)`,
+    `INSERT OR IGNORE INTO threads (thread_id, agent_jid, origin_jid, agent_name, created_at, kind) VALUES (?, ?, ?, ?, ?, ?)`,
   ).run(
     threadId,
     agentJid,
     originJid,
     agentName || null,
     new Date().toISOString(),
+    kind,
   );
 }
 
@@ -656,11 +669,32 @@ export function getThreadMessages(
 export function getThreadsForChat(chatJid: string): ThreadInfo[] {
   return db
     .prepare(
-      `SELECT t.thread_id, t.agent_jid, t.origin_jid, t.agent_name, t.created_at,
+      `SELECT t.thread_id, t.agent_jid, t.origin_jid, t.agent_name, t.created_at, t.kind,
               COUNT(m.id) as reply_count
        FROM threads t
        LEFT JOIN messages m ON m.thread_id = t.thread_id AND m.chat_jid = ?
        WHERE t.origin_jid = ?
+         AND (t.kind IS NULL OR t.kind = 'trigger')
+       GROUP BY t.thread_id
+       ORDER BY t.created_at DESC`,
+    )
+    .all(chatJid, chatJid) as ThreadInfo[];
+}
+
+/**
+ * Portal (side-drawer) threads for a chat. Separate from trigger threads
+ * so the inline ThreadView and drawer AgentPanel can each query only
+ * what they render.
+ */
+export function getPortalThreadsForChat(chatJid: string): ThreadInfo[] {
+  return db
+    .prepare(
+      `SELECT t.thread_id, t.agent_jid, t.origin_jid, t.agent_name, t.created_at, t.kind,
+              COUNT(m.id) as reply_count
+       FROM threads t
+       LEFT JOIN messages m ON m.thread_id = t.thread_id AND m.chat_jid = ?
+       WHERE t.origin_jid = ?
+         AND t.kind = 'portal'
        GROUP BY t.thread_id
        ORDER BY t.created_at DESC`,
     )

--- a/src/db.ts
+++ b/src/db.ts
@@ -579,6 +579,7 @@ export function getMessagesSince(
   limit: number = 200,
   includeBotMessages: boolean = false,
   excludeThreaded: boolean = false,
+  keepPortalThreads: boolean = false,
 ): NewMessage[] {
   // Filter bot messages using both the is_bot_message flag AND the content
   // prefix as a backstop for messages written before the migration ran.
@@ -587,7 +588,22 @@ export function getMessagesSince(
   const botFilter = includeBotMessages
     ? ''
     : 'AND is_bot_message = 0 AND content NOT LIKE ?';
-  const threadFilter = excludeThreaded ? 'AND thread_id IS NULL' : '';
+  // Three filter modes:
+  //   excludeThreaded=false                         → keep everything (default)
+  //   excludeThreaded=true, keepPortalThreads=false → hide all threaded (UI main feed)
+  //   excludeThreaded=true, keepPortalThreads=true  → hide trigger threads but keep
+  //       portal-thread content so coordinators can see specialist output they
+  //       delegated to. Without this, the coordinator would be blind to the
+  //       work that happened in its own portals.
+  let threadFilter = '';
+  if (excludeThreaded) {
+    threadFilter = keepPortalThreads
+      ? `AND (thread_id IS NULL OR EXISTS (
+           SELECT 1 FROM threads t
+           WHERE t.thread_id = messages.thread_id AND t.kind = 'portal'
+         ))`
+      : 'AND thread_id IS NULL';
+  }
   const sql = `
     SELECT * FROM (
       SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, thread_id, usage, run_id

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,10 +251,14 @@ function checkContextPressure(groupFolder: string, chatJid: string): void {
 }
 
 /** Broadcast agent progress (tool activity) to web UI clients */
-function broadcastProgress(chatJid: string, event: ProgressEvent): void {
+function broadcastProgress(
+  chatJid: string,
+  event: ProgressEvent,
+  threadId?: string,
+): void {
   for (const ch of channels) {
     if (ch.name === 'web' && 'broadcastAgentProgress' in ch) {
-      (ch as any).broadcastAgentProgress(chatJid, event);
+      (ch as any).broadcastAgentProgress(chatJid, event, threadId);
       break;
     }
   }
@@ -268,6 +272,17 @@ const activeThreads = new Map<
 // Callback set by the web channel to broadcast thread creation events
 let broadcastThreadCreated:
   | ((originJid: string, threadId: string, agentName: string) => void)
+  | null = null;
+// Callback for portal (side-drawer) thread openings. Distinct from
+// broadcastThreadCreated, which signals the inline ThreadView UX.
+let broadcastThreadOpened:
+  | ((
+      originJid: string,
+      threadId: string,
+      agentName: string,
+      kind: 'portal',
+      sourceAgent?: string,
+    ) => void)
   | null = null;
 
 async function deliverAgentMessage(
@@ -2785,6 +2800,9 @@ async function main(): Promise<void> {
   if (channelOpts.onThreadCreated) {
     broadcastThreadCreated = channelOpts.onThreadCreated;
   }
+  if (channelOpts.onThreadOpened) {
+    broadcastThreadOpened = channelOpts.onThreadOpened;
+  }
   if (channels.length === 0) {
     logger.fatal('No channels connected');
     process.exit(1);
@@ -3099,6 +3117,23 @@ async function main(): Promise<void> {
         agent.runtime,
       ).delegationTimeoutMs;
       const taskId = `delegation-${agent.name}-${Date.now()}`;
+      // Each delegation gets its own portal thread — the specialist's
+      // output drains into the side panel rather than the main chat.
+      const portalThreadId = `portal-${taskId}`;
+      createThread(
+        portalThreadId,
+        `${group.folder}/${agent.name}`,
+        chatJid,
+        agent.displayName,
+        'portal',
+      );
+      broadcastThreadOpened?.(
+        chatJid,
+        portalThreadId,
+        agent.displayName,
+        'portal',
+        sourceAgent,
+      );
       queue.enqueueDelegation(
         chatJid,
         taskId,
@@ -3142,7 +3177,12 @@ async function main(): Promise<void> {
           ];
 
           setActiveAgentName(chatJid, agent.displayName);
-          await channel.setTyping?.(chatJid, true);
+          await channel.setTyping?.(
+            chatJid,
+            true,
+            portalThreadId,
+            agent.displayName,
+          );
           // Intermediate TEXT blocks are shown as status in the typing indicator
 
           const status = await runAgent(
@@ -3169,7 +3209,13 @@ async function main(): Promise<void> {
                     // share the same chatJid so we must claim the name each time
                     setActiveAgentName(chatJid, agent.displayName);
                     if (
-                      await deliverAgentMessage(channel, chatJid, text, lease)
+                      await deliverAgentMessage(
+                        channel,
+                        chatJid,
+                        text,
+                        lease,
+                        portalThreadId,
+                      )
                     ) {
                       deliveredToUser = true;
                     }
@@ -3182,7 +3228,7 @@ async function main(): Promise<void> {
                 await channel.setTyping?.(
                   chatJid,
                   false,
-                  undefined,
+                  portalThreadId,
                   agent.displayName,
                 );
               }
@@ -3190,19 +3236,27 @@ async function main(): Promise<void> {
                 await channel.setTyping?.(
                   chatJid,
                   false,
-                  undefined,
+                  portalThreadId,
                   agent.displayName,
                 );
               }
             },
-            (event) => broadcastProgress(chatJid, event),
+            (event) => broadcastProgress(chatJid, event, portalThreadId),
             async (rawText) => {
               const text = rawText
                 .replace(/<internal>[\s\S]*?<\/internal>/g, '')
                 .trim();
               if (!text) return;
               setActiveAgentName(chatJid, agent.displayName);
-              if (await deliverAgentMessage(channel, chatJid, text, lease)) {
+              if (
+                await deliverAgentMessage(
+                  channel,
+                  chatJid,
+                  text,
+                  lease,
+                  portalThreadId,
+                )
+              ) {
                 deliveredToUser = true;
               }
             },
@@ -3210,7 +3264,15 @@ async function main(): Promise<void> {
             true, // isDelegation — use shorter timeout
             async (text) => {
               setActiveAgentName(chatJid, agent.displayName);
-              if (await deliverAgentMessage(channel, chatJid, text, lease)) {
+              if (
+                await deliverAgentMessage(
+                  channel,
+                  chatJid,
+                  text,
+                  lease,
+                  portalThreadId,
+                )
+              ) {
                 deliveredToUser = true;
               }
             },
@@ -3224,7 +3286,7 @@ async function main(): Promise<void> {
           await channel.setTyping?.(
             chatJid,
             false,
-            undefined,
+            portalThreadId,
             agent.displayName,
           );
           if (persistExplicitAgentStatus(chatJid, agent.name, '')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,6 +284,11 @@ let broadcastThreadOpened:
       sourceAgent?: string,
     ) => void)
   | null = null;
+// Callback for portal thread completion. The client clears the "live" flag
+// so only in-flight portals render in the drawer stack.
+let broadcastThreadClosed:
+  | ((originJid: string, threadId: string) => void)
+  | null = null;
 
 async function deliverAgentMessage(
   channel: Channel,
@@ -1010,6 +1015,7 @@ async function processGroupMessages(
     MAX_MESSAGES_PER_PROMPT,
     isMultiAgent, // includeBotMessages — coordinators must see specialist output
     !isThreadReply, // excludeThreaded — but include thread replies when processing a thread agent
+    isMultiAgent, // keepPortalThreads — coordinators need delegation output
   );
 
   if (missedMessages.length === 0) {
@@ -2803,6 +2809,9 @@ async function main(): Promise<void> {
   if (channelOpts.onThreadOpened) {
     broadcastThreadOpened = channelOpts.onThreadOpened;
   }
+  if (channelOpts.onThreadClosed) {
+    broadcastThreadClosed = channelOpts.onThreadClosed;
+  }
   if (channels.length === 0) {
     logger.fatal('No channels connected');
     process.exit(1);
@@ -3289,6 +3298,7 @@ async function main(): Promise<void> {
             portalThreadId,
             agent.displayName,
           );
+          broadcastThreadClosed?.(chatJid, portalThreadId);
           if (persistExplicitAgentStatus(chatJid, agent.name, '')) {
             logger.info(
               { jid: chatJid, agentName: agent.name },

--- a/src/model-capabilities.test.ts
+++ b/src/model-capabilities.test.ts
@@ -151,7 +151,10 @@ describe('buildMultiAgentContext', () => {
     const out = buildMultiAgentContext(ollamaSpec, [coord, ollamaSpec]);
     expect(out).not.toContain('mcp__nanoclaw__');
     expect(out).toContain('plain text');
-    expect(out).toContain('delivered to the user');
+    // Specialists write into portal side panels that the coordinator
+    // synthesizes; that framing replaced the old "delivered to the user"
+    // copy when portal routing landed.
+    expect(out).toContain('portal');
   });
 
   it('lists teammates regardless of capability profile', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface ThreadInfo {
   agent_name?: string;
   created_at: string;
   reply_count?: number;
+  kind?: 'trigger' | 'portal';
 }
 
 export interface Agent {

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -138,7 +138,5 @@ export const getTranscript = (groupFolder, runId) => {
   const qs = runId != null ? `&run_id=${encodeURIComponent(runId)}` : '';
   return fetchJson(`/api/transcript?group=${encodeURIComponent(groupFolder)}${qs}`);
 };
-export const getThreadMessages = (threadId) =>
-  fetchJson(`/api/thread-messages/${encodeURIComponent(threadId)}`);
 export const getAchievements = () => fetchJson('/api/achievements');
 export const getSessionPressure = () => fetchJson('/api/session/pressure');

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -138,5 +138,7 @@ export const getTranscript = (groupFolder, runId) => {
   const qs = runId != null ? `&run_id=${encodeURIComponent(runId)}` : '';
   return fetchJson(`/api/transcript?group=${encodeURIComponent(groupFolder)}${qs}`);
 };
+export const getThreadMessages = (threadId) =>
+  fetchJson(`/api/thread-messages/${encodeURIComponent(threadId)}`);
 export const getAchievements = () => fetchJson('/api/achievements');
 export const getSessionPressure = () => fetchJson('/api/session/pressure');

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -138,5 +138,7 @@ export const getTranscript = (groupFolder, runId) => {
   const qs = runId != null ? `&run_id=${encodeURIComponent(runId)}` : '';
   return fetchJson(`/api/transcript?group=${encodeURIComponent(groupFolder)}${qs}`);
 };
+export const getPortalThreads = (jid) =>
+  fetchJson(`/api/portal-threads/${encodeURIComponent(jid)}`);
 export const getAchievements = () => fetchJson('/api/achievements');
 export const getSessionPressure = () => fetchJson('/api/session/pressure');

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -76,9 +76,14 @@ function loadNotifLastRead() {
 export const notifications = signal(loadNotifHistory());
 export const notifLastReadAt = signal(loadNotifLastRead());
 export const flashMessageId = signal(null);
-// Side panel: { runId, groupFolder, usage? } when open, null when closed.
-// Phase 1 of side panels (issue #90) — retroactive agent session viewer.
+// Side panel: either { runId, groupFolder, usage? } (retroactive) or
+// { threadId, groupFolder, agentName, live: true } (live delegation portal).
+// Phase 2: live streaming for portal threads (issue #90).
 export const agentPanel = signal(null);
+// Portal threads keyed by thread_id. Populated by `thread_opened` SSE; live
+// `message` events route here instead of the inline ThreadView feed.
+// Shape: { [thread_id]: { kind, agentName, jid, messages: [], sourceAgent, openedAt } }
+export const portalThreads = signal({});
 export const unreadNotifCount = computed(() => {
   const lastRead = notifLastReadAt.value;
   return notifications.value.filter(
@@ -180,7 +185,28 @@ api.connectSSE(clientId);
 
 api.onSSE('message', (data) => {
   if (data.thread_id) {
-    // Thread message — append to open thread, update reply count, clear thread typing
+    // Portal thread message — route to drawer, not inline ThreadView
+    const portal = portalThreads.value[data.thread_id];
+    if (portal) {
+      portalThreads.value = {
+        ...portalThreads.value,
+        [data.thread_id]: {
+          ...portal,
+          messages: [
+            ...portal.messages,
+            {
+              id: data.message_id,
+              role: 'assistant',
+              content: data.text,
+              timestamp: data.timestamp,
+              senderName: data.sender_name,
+            },
+          ],
+        },
+      };
+      return;
+    }
+    // Trigger thread — append to inline ThreadView, update reply count, clear thread typing
     threadTyping.value = { ...threadTyping.value, [data.thread_id]: false };
     const threads = openThreads.value;
     if (threads[data.thread_id]) {
@@ -358,6 +384,38 @@ api.onSSE('context_pressure_cleared', (data) => {
   const nextDismissed = { ...dismissedPressure.value };
   delete nextDismissed[data.jid];
   dismissedPressure.value = nextDismissed;
+});
+
+api.onSSE('thread_opened', (data) => {
+  // A portal (side-drawer) thread was opened by a delegation or action.
+  // Register it so `message` events with this thread_id route to the drawer.
+  if (data.kind !== 'portal' || !data.thread_id) return;
+  const folder = groups.value.find((g) => g.jid === data.jid)?.folder;
+  portalThreads.value = {
+    ...portalThreads.value,
+    [data.thread_id]: {
+      kind: data.kind,
+      jid: data.jid,
+      agentName: data.agent_name,
+      sourceAgent: data.source_agent,
+      messages: [],
+      openedAt: Date.now(),
+    },
+  };
+  // Auto-open the drawer for the first portal in the active chat.
+  // Subsequent portals are registered but don't steal focus.
+  if (
+    data.jid === selectedJid.value &&
+    !agentPanel.value &&
+    folder
+  ) {
+    agentPanel.value = {
+      threadId: data.thread_id,
+      groupFolder: folder,
+      agentName: data.agent_name,
+      live: true,
+    };
+  }
 });
 
 api.onSSE('thread_created', async (data) => {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -391,6 +391,8 @@ api.onSSE('thread_opened', (data) => {
   // Register it so `message` events with this thread_id route to the drawer.
   if (data.kind !== 'portal' || !data.thread_id) return;
   const folder = groups.value.find((g) => g.jid === data.jid)?.folder;
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
   portalThreads.value = {
     ...portalThreads.value,
     [data.thread_id]: {
@@ -399,23 +401,42 @@ api.onSSE('thread_opened', (data) => {
       agentName: data.agent_name,
       sourceAgent: data.source_agent,
       messages: [],
-      openedAt: Date.now(),
+      openedAt: now,
+      createdAt: nowIso,
+      replyCount: 0,
+      live: true, // in-session — shows in drawer stack until drawer is closed
+      running: true, // actively running — drives the LIVE badge
     },
   };
-  // Auto-open the drawer for the first portal in the active chat.
-  // Subsequent portals are registered but don't steal focus.
-  if (
-    data.jid === selectedJid.value &&
-    !agentPanel.value &&
-    folder
-  ) {
-    agentPanel.value = {
-      threadId: data.thread_id,
-      groupFolder: folder,
-      agentName: data.agent_name,
-      live: true,
-    };
+  // New live portal — always switch the drawer to the portals stack and
+  // focus on the new thread. If the user was inspecting a historical
+  // single portal, live activity takes precedence (they can click a pill
+  // to get back). If the drawer is on a retroactive transcript view
+  // (runId), leave it alone.
+  if (data.jid === selectedJid.value && folder) {
+    const cur = agentPanel.value;
+    if (!cur || cur.mode === 'portals' || cur.mode === 'portal-single') {
+      agentPanel.value = {
+        mode: 'portals',
+        groupFolder: folder,
+        focusedThreadId: data.thread_id,
+      };
+    }
   }
+});
+
+api.onSSE('thread_closed', (data) => {
+  // Portal's agent run finished — clear the running flag so the LIVE
+  // badge drops. The portal itself stays in the stack (live=true) so
+  // the user can still read what the agent said; it drops out of the
+  // stack only when the drawer is closed (handled separately).
+  if (!data.thread_id) return;
+  const portal = portalThreads.value[data.thread_id];
+  if (!portal) return;
+  portalThreads.value = {
+    ...portalThreads.value,
+    [data.thread_id]: { ...portal, running: false },
+  };
 });
 
 api.onSSE('thread_created', async (data) => {
@@ -604,9 +625,10 @@ export async function selectGroup(jid) {
   // are appended to a clean slate (selectedJid is already set above).
   messages.value = [];
 
-  const [msgData, threadData] = await Promise.all([
+  const [msgData, threadData, portalData] = await Promise.all([
     api.getMessages(jid),
     api.getThreads(jid),
+    api.getPortalThreads(jid),
   ]);
 
   // Build the DB message list, then merge any SSE messages that arrived
@@ -639,6 +661,40 @@ export async function selectGroup(jid) {
   threadMeta.value = meta;
   openThreads.value = {};
   threadTyping.value = {};
+
+  // Build portal index scoped to this chat. Portals loaded from the server
+  // power the pills in the main feed (persistent recall); only portals
+  // opened live in the current session (live: true) render in the drawer
+  // stack. That way a chat with 16 historical portals doesn't flood the
+  // drawer — you see pills inline and click one to inspect it.
+  const portalsByThread = {};
+  for (const t of portalData.threads || []) {
+    portalsByThread[t.thread_id] = {
+      kind: 'portal',
+      jid,
+      agentName: t.agent_name,
+      sourceAgent: null,
+      messages: [],
+      openedAt: new Date(t.created_at).getTime(),
+      createdAt: t.created_at,
+      replyCount: t.reply_count || 0,
+      live: false,
+    };
+  }
+  // Preserve live portals from this session even if DB doesn't have them yet.
+  for (const [tid, existing] of Object.entries(portalThreads.value)) {
+    if (existing.jid === jid && existing.live && !portalsByThread[tid]) {
+      portalsByThread[tid] = existing;
+    } else if (existing.jid === jid && existing.live && portalsByThread[tid]) {
+      // DB row exists AND it's the live session portal — preserve live flag
+      portalsByThread[tid] = {
+        ...portalsByThread[tid],
+        ...existing,
+        live: true,
+      };
+    }
+  }
+  portalThreads.value = portalsByThread;
 }
 
 export async function handleSend(content) {

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact';
 import { useEffect, useState } from 'preact/hooks';
-import { agentPanel } from '../app.js';
+import { agentPanel, portalThreads } from '../app.js';
 import * as api from '../api.js';
 
 function formatTime(ts) {
@@ -83,18 +83,24 @@ function Entry({ entry }) {
   return null;
 }
 
-export function AgentPanel() {
-  const state = agentPanel.value;
+function LiveMessage({ msg }) {
+  const isUser = msg.role === 'user';
+  return html`
+    <div class="flex flex-col gap-1 py-2 px-3 rounded-md ${isUser ? 'bg-userbg' : 'bg-asstbg'}">
+      <div class="text-[10px] text-txt-muted font-mono">
+        ${msg.senderName || (isUser ? 'user' : 'assistant')} · ${formatTime(msg.timestamp)}
+      </div>
+      <div class="text-xs text-txt-2 whitespace-pre-wrap break-words">${msg.content}</div>
+    </div>
+  `;
+}
+
+function RetroactivePanel({ state }) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (!state) {
-      setData(null);
-      setError(null);
-      return;
-    }
     const { runId, groupFolder } = state;
     let cancelled = false;
     setLoading(true);
@@ -112,7 +118,122 @@ export function AgentPanel() {
         setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [state?.runId, state?.groupFolder]);
+  }, [state.runId, state.groupFolder]);
+
+  const run = data?.run;
+  const timeline = data?.timeline || [];
+
+  return html`
+    <header class="flex items-center justify-between px-4 py-3 border-b border-border">
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <h3 class="text-sm font-semibold truncate">Agent conversation</h3>
+        ${run && html`
+          <div class="text-[11px] text-txt-muted font-mono truncate">
+            ${formatTime(run.timestamp)}
+            ${run.duration_ms ? ` · ${formatDuration(run.duration_ms)}` : ''}
+            ${run.num_turns ? ` · ${run.num_turns} turn${run.num_turns !== 1 ? 's' : ''}` : ''}
+            ${run.cost_usd ? ` · ${formatCost(run.cost_usd)}` : ''}
+          </div>
+        `}
+      </div>
+      <${CloseButton} />
+    </header>
+    <div class="flex-1 overflow-y-auto p-3 flex flex-col gap-1.5">
+      ${loading && html`<div class="text-xs text-txt-muted p-4 text-center">Loading transcript...</div>`}
+      ${error && html`
+        <div class="text-xs text-err p-4 text-center">
+          ${error}
+          ${state.runId == null && html`
+            <div class="text-txt-muted mt-2">No run ID recorded for this message. Older messages may not have this data.</div>
+          `}
+        </div>
+      `}
+      ${!loading && !error && timeline.length === 0 && html`
+        <div class="text-xs text-txt-muted p-4 text-center">No transcript entries in this run window.</div>
+      `}
+      ${timeline.map((entry, i) => html`<${Entry} key=${i} entry=${entry} />`)}
+    </div>
+  `;
+}
+
+function LivePanel({ state }) {
+  const portal = portalThreads.value[state.threadId];
+  const [historicalMsgs, setHistoricalMsgs] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getThreadMessages(state.threadId)
+      .then((resp) => {
+        if (cancelled) return;
+        const msgs = (resp?.messages || []).map((m) => ({
+          id: m.id,
+          role: m.is_bot_message || m.is_from_me ? 'assistant' : 'user',
+          content: m.content,
+          timestamp: m.timestamp,
+          senderName: m.sender_name,
+        }));
+        setHistoricalMsgs(msgs);
+        setLoading(false);
+      })
+      .catch(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [state.threadId]);
+
+  // Merge historical and live messages, dedup by id
+  const liveMsgs = portal?.messages || [];
+  const seen = new Set(historicalMsgs.map((m) => m.id).filter(Boolean));
+  const combined = [
+    ...historicalMsgs,
+    ...liveMsgs.filter((m) => !m.id || !seen.has(m.id)),
+  ];
+
+  return html`
+    <header class="flex items-center justify-between px-4 py-3 border-b border-border">
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <div class="flex items-center gap-2">
+          <h3 class="text-sm font-semibold truncate">${state.agentName || 'Agent'}</h3>
+          <span class="text-[10px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/20 text-accent">live</span>
+        </div>
+        ${portal?.sourceAgent && html`
+          <div class="text-[11px] text-txt-muted font-mono truncate">
+            delegated by ${portal.sourceAgent}
+          </div>
+        `}
+      </div>
+      <${CloseButton} />
+    </header>
+    <div class="flex-1 overflow-y-auto p-3 flex flex-col gap-1.5">
+      ${loading && combined.length === 0 && html`
+        <div class="text-xs text-txt-muted p-4 text-center">Loading thread...</div>
+      `}
+      ${!loading && combined.length === 0 && html`
+        <div class="text-xs text-txt-muted p-4 text-center">
+          Waiting for agent output... <span class="typing-dot inline-block ml-1" />
+        </div>
+      `}
+      ${combined.map((m, i) => html`<${LiveMessage} key=${m.id || i} msg=${m} />`)}
+    </div>
+  `;
+}
+
+function CloseButton() {
+  return html`
+    <button
+      class="w-7 h-7 flex items-center justify-center rounded-md text-txt-2 hover:bg-bg-hover hover:text-txt transition-colors shrink-0 ml-2"
+      title="Close"
+      onClick=${() => { agentPanel.value = null; }}
+    >
+      <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+      </svg>
+    </button>
+  `;
+}
+
+export function AgentPanel() {
+  const state = agentPanel.value;
 
   useEffect(() => {
     if (!state) return;
@@ -125,58 +246,16 @@ export function AgentPanel() {
 
   if (!state) return null;
 
-  const run = data?.run;
-  const timeline = data?.timeline || [];
-
-  function close() {
-    agentPanel.value = null;
-  }
+  const close = () => { agentPanel.value = null; };
 
   return html`
-    <div
-      class="fixed inset-0 z-40 bg-black/40"
-      onClick=${close}
-    />
+    <div class="fixed inset-0 z-40 bg-black/40" onClick=${close} />
     <aside
       class="fixed top-0 right-0 h-full w-full md:w-[440px] lg:w-[520px] z-50 bg-bg-2 border-l border-border shadow-xl flex flex-col"
     >
-      <header class="flex items-center justify-between px-4 py-3 border-b border-border">
-        <div class="flex flex-col gap-0.5 min-w-0">
-          <h3 class="text-sm font-semibold truncate">Agent conversation</h3>
-          ${run && html`
-            <div class="text-[11px] text-txt-muted font-mono truncate">
-              ${formatTime(run.timestamp)}
-              ${run.duration_ms ? ` · ${formatDuration(run.duration_ms)}` : ''}
-              ${run.num_turns ? ` · ${run.num_turns} turn${run.num_turns !== 1 ? 's' : ''}` : ''}
-              ${run.cost_usd ? ` · ${formatCost(run.cost_usd)}` : ''}
-            </div>
-          `}
-        </div>
-        <button
-          class="w-7 h-7 flex items-center justify-center rounded-md text-txt-2 hover:bg-bg-hover hover:text-txt transition-colors shrink-0 ml-2"
-          title="Close"
-          onClick=${close}
-        >
-          <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
-          </svg>
-        </button>
-      </header>
-      <div class="flex-1 overflow-y-auto p-3 flex flex-col gap-1.5">
-        ${loading && html`<div class="text-xs text-txt-muted p-4 text-center">Loading transcript...</div>`}
-        ${error && html`
-          <div class="text-xs text-err p-4 text-center">
-            ${error}
-            ${state.runId == null && html`
-              <div class="text-txt-muted mt-2">No run ID recorded for this message. Older messages may not have this data.</div>
-            `}
-          </div>
-        `}
-        ${!loading && !error && timeline.length === 0 && html`
-          <div class="text-xs text-txt-muted p-4 text-center">No transcript entries in this run window.</div>
-        `}
-        ${timeline.map((entry, i) => html`<${Entry} key=${i} entry=${entry} />`)}
-      </div>
+      ${state.live
+        ? html`<${LivePanel} state=${state} />`
+        : html`<${RetroactivePanel} state=${state} />`}
     </aside>
   `;
 }

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -246,12 +246,15 @@ export function AgentPanel() {
 
   if (!state) return null;
 
+  // Mobile: overlay (with backdrop). Desktop (md+): docked side panel that
+  // takes real layout space next to ChatView.
   const close = () => { agentPanel.value = null; };
 
   return html`
-    <div class="fixed inset-0 z-40 bg-black/40" onClick=${close} />
+    <div class="fixed inset-0 z-40 bg-black/40 md:hidden" onClick=${close} />
     <aside
-      class="fixed top-0 right-0 h-full w-full md:w-[440px] lg:w-[520px] z-50 bg-bg-2 border-l border-border shadow-xl flex flex-col"
+      class="fixed top-0 right-0 h-full w-full z-50 bg-bg-2 border-l border-border shadow-xl flex flex-col
+             md:static md:z-auto md:shadow-none md:w-[440px] lg:w-[520px] md:shrink-0"
     >
       ${state.live
         ? html`<${LivePanel} state=${state} />`

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -1,7 +1,8 @@
 import { html } from 'htm/preact';
-import { useEffect, useState } from 'preact/hooks';
-import { agentPanel, portalThreads } from '../app.js';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { agentPanel, portalThreads, selectedJid } from '../app.js';
 import * as api from '../api.js';
+import { MessageBody } from './MessageBody.js';
 
 function formatTime(ts) {
   if (!ts) return '';
@@ -86,11 +87,162 @@ function Entry({ entry }) {
 function LiveMessage({ msg }) {
   const isUser = msg.role === 'user';
   return html`
-    <div class="flex flex-col gap-1 py-2 px-3 rounded-md ${isUser ? 'bg-userbg' : 'bg-asstbg'}">
+    <div class="flex flex-col gap-1 py-2 px-3 rounded-md overflow-hidden break-words ${isUser ? 'bg-userbg' : 'bg-asstbg'}">
       <div class="text-[10px] text-txt-muted font-mono">
         ${msg.senderName || (isUser ? 'user' : 'assistant')} · ${formatTime(msg.timestamp)}
       </div>
-      <div class="text-xs text-txt-2 whitespace-pre-wrap break-words">${msg.content}</div>
+      <div class="text-xs leading-relaxed">
+        <${MessageBody} content=${msg.content} />
+      </div>
+    </div>
+  `;
+}
+
+/** Renders one portal (specialist) as a collapsible section in the stack.
+ *  isRunning drives the LIVE badge; sections stay in the stack after the
+ *  agent finishes so the user can keep reading. */
+function PortalSection({ threadId, portal, focused, isRunning }) {
+  const sectionRef = useRef(null);
+  const [historicalMsgs, setHistoricalMsgs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getThreadMessages(threadId)
+      .then((resp) => {
+        if (cancelled) return;
+        const msgs = (resp?.messages || []).map((m) => ({
+          id: m.id,
+          role: m.is_bot_message || m.is_from_me ? 'assistant' : 'user',
+          content: m.content,
+          timestamp: m.timestamp,
+          senderName: m.sender_name,
+        }));
+        setHistoricalMsgs(msgs);
+        setLoading(false);
+      })
+      .catch(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [threadId]);
+
+  useEffect(() => {
+    if (focused && sectionRef.current) {
+      sectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      setOpen(true);
+    }
+  }, [focused]);
+
+  const liveMsgs = portal?.messages || [];
+  const seen = new Set(historicalMsgs.map((m) => m.id).filter(Boolean));
+  const combined = [
+    ...historicalMsgs,
+    ...liveMsgs.filter((m) => !m.id || !seen.has(m.id)),
+  ];
+  const count = combined.length;
+
+  return html`
+    <section
+      ref=${sectionRef}
+      class="flex flex-col border border-border rounded-md overflow-hidden ${focused ? 'ring-1 ring-accent/60' : ''}"
+    >
+      <button
+        class="flex items-center gap-2 px-3 py-2 bg-bg-3 hover:bg-bg-hover transition-colors text-left cursor-pointer"
+        onClick=${() => setOpen(!open)}
+      >
+        <span class="text-[9px] transition-transform ${open ? 'rotate-90' : ''}">\u25B6</span>
+        <span class="text-xs font-semibold truncate">${portal.agentName || 'Agent'}</span>
+        ${isRunning && html`
+          <span class="text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/20 text-accent">live</span>
+        `}
+        <span class="text-[10px] text-txt-muted font-mono ml-auto shrink-0">
+          ${count} msg${count !== 1 ? 's' : ''}
+        </span>
+      </button>
+      ${open && html`
+        <div class="p-2 flex flex-col gap-1.5 bg-bg-2">
+          ${loading && combined.length === 0 && html`
+            <div class="text-xs text-txt-muted p-2 text-center">Loading...</div>
+          `}
+          ${!loading && combined.length === 0 && html`
+            <div class="text-xs text-txt-muted p-2 text-center">
+              Waiting for agent output... <span class="typing-dot inline-block ml-1" />
+            </div>
+          `}
+          ${combined.map((m, i) => html`<${LiveMessage} key=${m.id || i} msg=${m} />`)}
+        </div>
+      `}
+    </section>
+  `;
+}
+
+function PortalsPanel({ state }) {
+  const portals = portalThreads.value;
+  const jid = selectedJid.value;
+  // Only show live (this-session) portals in the drawer stack. Historical
+  // portals are reachable via pills in the main feed — clicking a pill
+  // opens the single-portal view (PortalSinglePanel).
+  const entries = Object.entries(portals)
+    .filter(([, p]) => p.jid === jid && p.live)
+    .sort((a, b) => (b[1].openedAt || 0) - (a[1].openedAt || 0)); // newest first
+
+  return html`
+    <header class="flex items-center justify-between px-4 py-3 border-b border-border">
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <h3 class="text-sm font-semibold truncate">
+          ${entries.length > 1 ? `${entries.length} live portals` : 'Agent portal'}
+        </h3>
+        <div class="text-[11px] text-txt-muted font-mono truncate">
+          side work · click header to collapse
+        </div>
+      </div>
+      <${CloseButton} />
+    </header>
+    <div class="flex-1 overflow-y-auto p-3 flex flex-col gap-2">
+      ${entries.length === 0 && html`
+        <div class="text-xs text-txt-muted p-4 text-center">
+          No active portals. Click a portal pill in the chat to view a past session.
+        </div>
+      `}
+      ${entries.map(([threadId, portal]) => html`
+        <${PortalSection}
+          key=${threadId}
+          threadId=${threadId}
+          portal=${portal}
+          focused=${state.focusedThreadId === threadId}
+          isRunning=${!!portal.running}
+        />
+      `)}
+    </div>
+  `;
+}
+
+function PortalSinglePanel({ state }) {
+  const portals = portalThreads.value;
+  const portal = portals[state.threadId];
+  return html`
+    <header class="flex items-center justify-between px-4 py-3 border-b border-border">
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <h3 class="text-sm font-semibold truncate">
+          ${portal?.agentName || 'Agent'}'s portal
+        </h3>
+        <div class="text-[11px] text-txt-muted font-mono truncate">
+          ${portal?.createdAt ? formatTime(portal.createdAt) : ''}
+          ${portal?.sourceAgent ? ` · delegated by ${portal.sourceAgent}` : ''}
+        </div>
+      </div>
+      <${CloseButton} />
+    </header>
+    <div class="flex-1 overflow-y-auto p-3 flex flex-col gap-2">
+      ${portal
+        ? html`<${PortalSection}
+            threadId=${state.threadId}
+            portal=${portal}
+            focused=${true}
+            isLive=${!!portal.live}
+          />`
+        : html`<div class="text-xs text-txt-muted p-4 text-center">Portal not found.</div>`}
     </div>
   `;
 }
@@ -156,66 +308,18 @@ function RetroactivePanel({ state }) {
   `;
 }
 
-function LivePanel({ state }) {
-  const portal = portalThreads.value[state.threadId];
-  const [historicalMsgs, setHistoricalMsgs] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    api
-      .getThreadMessages(state.threadId)
-      .then((resp) => {
-        if (cancelled) return;
-        const msgs = (resp?.messages || []).map((m) => ({
-          id: m.id,
-          role: m.is_bot_message || m.is_from_me ? 'assistant' : 'user',
-          content: m.content,
-          timestamp: m.timestamp,
-          senderName: m.sender_name,
-        }));
-        setHistoricalMsgs(msgs);
-        setLoading(false);
-      })
-      .catch(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [state.threadId]);
-
-  // Merge historical and live messages, dedup by id
-  const liveMsgs = portal?.messages || [];
-  const seen = new Set(historicalMsgs.map((m) => m.id).filter(Boolean));
-  const combined = [
-    ...historicalMsgs,
-    ...liveMsgs.filter((m) => !m.id || !seen.has(m.id)),
-  ];
-
-  return html`
-    <header class="flex items-center justify-between px-4 py-3 border-b border-border">
-      <div class="flex flex-col gap-0.5 min-w-0">
-        <div class="flex items-center gap-2">
-          <h3 class="text-sm font-semibold truncate">${state.agentName || 'Agent'}</h3>
-          <span class="text-[10px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/20 text-accent">live</span>
-        </div>
-        ${portal?.sourceAgent && html`
-          <div class="text-[11px] text-txt-muted font-mono truncate">
-            delegated by ${portal.sourceAgent}
-          </div>
-        `}
-      </div>
-      <${CloseButton} />
-    </header>
-    <div class="flex-1 overflow-y-auto p-3 flex flex-col gap-1.5">
-      ${loading && combined.length === 0 && html`
-        <div class="text-xs text-txt-muted p-4 text-center">Loading thread...</div>
-      `}
-      ${!loading && combined.length === 0 && html`
-        <div class="text-xs text-txt-muted p-4 text-center">
-          Waiting for agent output... <span class="typing-dot inline-block ml-1" />
-        </div>
-      `}
-      ${combined.map((m, i) => html`<${LiveMessage} key=${m.id || i} msg=${m} />`)}
-    </div>
-  `;
+function closeDrawer() {
+  // Closing the drawer clears the "live" flag on all portals — they stay
+  // in portalThreads for pill recall but drop out of the stack. The next
+  // time the user opens the drawer (via pill click or new thread_opened),
+  // the stack starts fresh.
+  const portals = portalThreads.value;
+  const cleared = {};
+  for (const [tid, p] of Object.entries(portals)) {
+    cleared[tid] = p.live ? { ...p, live: false, running: false } : p;
+  }
+  portalThreads.value = cleared;
+  agentPanel.value = null;
 }
 
 function CloseButton() {
@@ -223,7 +327,7 @@ function CloseButton() {
     <button
       class="w-7 h-7 flex items-center justify-center rounded-md text-txt-2 hover:bg-bg-hover hover:text-txt transition-colors shrink-0 ml-2"
       title="Close"
-      onClick=${() => { agentPanel.value = null; }}
+      onClick=${closeDrawer}
     >
       <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
         <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
@@ -238,7 +342,7 @@ export function AgentPanel() {
   useEffect(() => {
     if (!state) return;
     const onKey = (e) => {
-      if (e.key === 'Escape') agentPanel.value = null;
+      if (e.key === 'Escape') closeDrawer();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -246,9 +350,16 @@ export function AgentPanel() {
 
   if (!state) return null;
 
-  // Mobile: overlay (with backdrop). Desktop (md+): docked side panel that
-  // takes real layout space next to ChatView.
-  const close = () => { agentPanel.value = null; };
+  const close = closeDrawer;
+
+  let body;
+  if (state.mode === 'portals') {
+    body = html`<${PortalsPanel} state=${state} />`;
+  } else if (state.mode === 'portal-single') {
+    body = html`<${PortalSinglePanel} state=${state} />`;
+  } else {
+    body = html`<${RetroactivePanel} state=${state} />`;
+  }
 
   return html`
     <div class="fixed inset-0 z-40 bg-black/40 md:hidden" onClick=${close} />
@@ -256,9 +367,7 @@ export function AgentPanel() {
       class="fixed top-0 right-0 h-full w-full z-50 bg-bg-2 border-l border-border shadow-xl flex flex-col
              md:static md:z-auto md:shadow-none md:w-[440px] lg:w-[520px] md:shrink-0"
     >
-      ${state.live
-        ? html`<${LivePanel} state=${state} />`
-        : html`<${RetroactivePanel} state=${state} />`}
+      ${body}
     </aside>
   `;
 }

--- a/web/js/components/Message.js
+++ b/web/js/components/Message.js
@@ -1,10 +1,8 @@
 import { html } from 'htm/preact';
 import { useState } from 'preact/hooks';
-import { parseBlocks } from '../block-parser.js';
-import { BlockRenderer } from './blocks/BlockRenderer.js';
-import { md } from '../markdown.js';
 import { selectedGroup } from '../app.js';
 import { openAgentPanel } from './AgentPanel.js';
+import { MessageBody } from './MessageBody.js';
 
 // Consistent color for each agent name (hash → HSL hue)
 const AGENT_COLORS = {};
@@ -121,19 +119,13 @@ export function Message({ role, content, timestamp, senderName, isError, compact
 
   const errorClass = isError ? 'border-err/30' : '';
 
-  const blocks = parseBlocks(content);
-
   return html`
     <div class="${sizeClass} leading-relaxed ${bubbleClass} ${errorClass} overflow-hidden break-words"
       ${showAgentBadge ? { style: `border-left: 3px solid ${nameColor}` } : {}}>
       ${showAgentBadge && html`
         <div class="text-[11px] font-semibold mb-1" style="color: ${nameColor}">${senderName}</div>
       `}
-      ${blocks
-        ? html`<div class="block-container">
-            ${blocks.map((block, i) => html`<${BlockRenderer} key=${i} block=${block} />`)}
-          </div>`
-        : html`<div class="prose" dangerouslySetInnerHTML=${{ __html: md(content) }} />`}
+      <${MessageBody} content=${content} />
       <div class="text-[11px] text-txt-muted mt-1.5">
         ${senderName && !showAgentBadge ? `${senderName} \u00B7 ${time}` : time}
       </div>

--- a/web/js/components/MessageBody.js
+++ b/web/js/components/MessageBody.js
@@ -1,0 +1,35 @@
+import { html } from 'htm/preact';
+import { parseBlocks } from '../block-parser.js';
+import { BlockRenderer } from './blocks/BlockRenderer.js';
+import { md } from '../markdown.js';
+import { pendingInput } from '../app.js';
+
+// Mentions (@agent) in rendered markdown carry data-trigger. Clicking one
+// injects the trigger into the chat input. Handled here so every surface
+// (main feed, threads, drawer portals) gets the behavior automatically.
+function handleMentionClick(e) {
+  const mention = e.target.closest('.mention');
+  if (!mention) return;
+  const trigger = mention.dataset.trigger;
+  if (trigger) pendingInput.value = trigger;
+}
+
+/**
+ * Renders a message body with the same rich content pipeline used
+ * everywhere (main feed, threads, drawer portals, future multi-panel).
+ * Prefers structured block rendering when the content parses as blocks,
+ * falls back to markdown for plain text. Keep this the single path for
+ * message content so new surfaces get the same behavior for free.
+ */
+export function MessageBody({ content }) {
+  if (!content) return null;
+  const blocks = parseBlocks(content);
+  if (blocks) {
+    return html`
+      <div class="block-container" onClick=${handleMentionClick}>
+        ${blocks.map((block, i) => html`<${BlockRenderer} key=${i} block=${block} />`)}
+      </div>
+    `;
+  }
+  return html`<div class="prose" onClick=${handleMentionClick} dangerouslySetInnerHTML=${{ __html: md(content) }} />`;
+}

--- a/web/js/components/MessageList.js
+++ b/web/js/components/MessageList.js
@@ -8,15 +8,16 @@ import {
   threadTyping,
   toggleThread,
   handleThreadReply,
-  pendingInput,
   currentWorkState,
   agentProgress,
   selectedJid,
   flashMessageId,
+  portalThreads,
 } from '../app.js';
 import { Message } from './Message.js';
 import { ThreadView } from './ThreadView.js';
 import { TypingIndicator } from './TypingIndicator.js';
+import { PortalPill } from './PortalPill.js';
 
 const SCROLL_THRESHOLD = 80;
 
@@ -82,60 +83,73 @@ export function MessageList() {
     setUnread(0);
   }
 
-  function onClickMention(e) {
-    const mention = e.target.closest('.mention');
-    if (mention) {
-      const trigger = mention.dataset.trigger;
-      if (trigger) pendingInput.value = trigger;
-    }
-  }
+  // Interleave portal pills with regular messages by timestamp. Pills are
+  // rendered as pseudo-entries; each one is scoped to the current chat.
+  const portals = portalThreads.value;
+  const portalEntries = Object.entries(portals)
+    .filter(([, p]) => p.jid === jid)
+    .map(([threadId, p]) => ({
+      kind: 'portal',
+      threadId,
+      timestamp: p.createdAt || new Date(p.openedAt).toISOString(),
+    }));
+  const visibleMsgs = msgs
+    .filter((m) => m.senderName !== 'System')
+    .map((m) => ({ kind: 'message', msg: m, timestamp: m.timestamp }));
+  const timeline = [...visibleMsgs, ...portalEntries].sort((a, b) => {
+    const ta = new Date(a.timestamp || 0).getTime();
+    const tb = new Date(b.timestamp || 0).getTime();
+    return ta - tb;
+  });
 
   return html`
     <div class="flex-1 relative flex flex-col min-h-0">
-    <div ref=${containerRef} onScroll=${onScroll} class="flex-1 overflow-y-auto p-3 md:p-5 flex flex-col gap-3" onClick=${onClickMention}>
-      ${msgs.length === 0 && !showActivity
+    <div ref=${containerRef} onScroll=${onScroll} class="flex-1 overflow-y-auto p-3 md:p-5 flex flex-col gap-3">
+      ${timeline.length === 0 && !showActivity
         ? html`
             <div class="flex-1 flex items-center justify-center">
               <p class="text-txt-muted text-sm">No messages yet. Start the conversation below.</p>
             </div>
           `
-        : msgs.filter((m) => m.senderName !== 'System').map(
-            (m, i) => {
-              const thread = m.id ? threads[m.id] : null;
-              const flashing = m.id && flashMessageId.value === m.id;
-              return html`
-                <div
-                  key=${i}
-                  data-role=${m.role}
-                  id=${m.id ? `msg-${m.id}` : undefined}
-                  class=${flashing ? 'notif-flash' : ''}
-                >
-                  <${Message}
-                    role=${m.role}
-                    content=${m.content}
-                    timestamp=${m.timestamp}
-                    senderName=${m.senderName}
-                    isError=${m.isError}
-                    usage=${m.usage}
-                    toolHistory=${m.toolHistory}
-                    runId=${m.runId}
+        : timeline.map((entry, i) => {
+            if (entry.kind === 'portal') {
+              return html`<${PortalPill} key=${`portal-${entry.threadId}`} threadId=${entry.threadId} />`;
+            }
+            const m = entry.msg;
+            const thread = m.id ? threads[m.id] : null;
+            const flashing = m.id && flashMessageId.value === m.id;
+            return html`
+              <div
+                key=${m.id || i}
+                data-role=${m.role}
+                id=${m.id ? `msg-${m.id}` : undefined}
+                class=${flashing ? 'notif-flash' : ''}
+              >
+                <${Message}
+                  role=${m.role}
+                  content=${m.content}
+                  timestamp=${m.timestamp}
+                  senderName=${m.senderName}
+                  isError=${m.isError}
+                  usage=${m.usage}
+                  toolHistory=${m.toolHistory}
+                  runId=${m.runId}
+                />
+                ${thread && html`
+                  <${ThreadView}
+                    threadId=${m.id}
+                    agentName=${thread.agent_name}
+                    messages=${expanded[m.id] || []}
+                    replyCount=${thread.reply_count || 0}
+                    isExpanded=${!!expanded[m.id]}
+                    isTyping=${!!tTyping[m.id]}
+                    onToggle=${toggleThread}
+                    onReply=${handleThreadReply}
                   />
-                  ${thread && html`
-                    <${ThreadView}
-                      threadId=${m.id}
-                      agentName=${thread.agent_name}
-                      messages=${expanded[m.id] || []}
-                      replyCount=${thread.reply_count || 0}
-                      isExpanded=${!!expanded[m.id]}
-                      isTyping=${!!tTyping[m.id]}
-                      onToggle=${toggleThread}
-                      onReply=${handleThreadReply}
-                    />
-                  `}
-                </div>
-              `;
-            },
-          )}
+                `}
+              </div>
+            `;
+          })}
       ${showActivity && html`<${TypingIndicator} />`}
     </div>
     ${unread > 0 && html`

--- a/web/js/components/PortalPill.js
+++ b/web/js/components/PortalPill.js
@@ -1,0 +1,47 @@
+import { html } from 'htm/preact';
+import { agentPanel, portalThreads, selectedGroup } from '../app.js';
+
+export function openPortalInDrawer(threadId) {
+  const group = selectedGroup.value;
+  if (!group) return;
+  const portal = portalThreads.value[threadId];
+  // Live portals open in the "portals" stack (focused on the clicked one);
+  // historical portals open solo in a single-portal view.
+  if (portal?.live) {
+    agentPanel.value = {
+      mode: 'portals',
+      groupFolder: group.folder,
+      focusedThreadId: threadId,
+    };
+  } else {
+    agentPanel.value = {
+      mode: 'portal-single',
+      groupFolder: group.folder,
+      threadId,
+    };
+  }
+}
+
+export function PortalPill({ threadId }) {
+  const portal = portalThreads.value[threadId];
+  if (!portal) return null;
+
+  const count = portal.messages.length || portal.replyCount || 0;
+  const subtitle = portal.sourceAgent
+    ? `delegated by ${portal.sourceAgent}`
+    : count
+      ? `${count} message${count !== 1 ? 's' : ''}`
+      : 'running...';
+
+  return html`
+    <button
+      class="self-start flex items-center gap-2 px-3 py-1.5 rounded-full bg-bg-3 border border-border text-[11px] text-txt-2 hover:border-accent hover:text-accent transition-colors cursor-pointer max-w-[85%]"
+      onClick=${() => openPortalInDrawer(threadId)}
+      title="Open portal"
+    >
+      <span class="text-accent">\u2197</span>
+      <span class="font-medium truncate">${portal.agentName || 'Agent'}'s portal</span>
+      <span class="text-txt-muted truncate">· ${subtitle}</span>
+    </button>
+  `;
+}


### PR DESCRIPTION
## Summary

Second cut of #90. Delegations now drain into a docked side-drawer "portal" instead of cluttering the main feed. Multi-agent teams immediately benefit — each specialist runs in its own portal, the drawer shows all live portals stacked vertically, and persistent pills in the main feed keep every portal recallable.

### Mechanism
- New `threads.kind` column: `'trigger'` (existing @-mention inline reply chains) or `'portal'` (new side-drawer work). Existing trigger-thread UX untouched.
- Every delegation mints a portal `thread_id` and tags the specialist's output with it (text, progress, typing). Routing reuses the existing `deliverAgentMessage(..., threadId)` / `channel.sendMessage(jid, text, threadId)` path.
- New `thread_opened` / `thread_closed` SSE events distinct from `thread_created` so the drawer can auto-open and drop LIVE badges without touching the inline ThreadView path.

### UX
- **Docked drawer** on desktop (md+). On mobile, falls back to overlay with backdrop.
- **Stacked vertical sections** — one per live portal, newest on top. Each has a LIVE badge while `running`, collapsible header, and a message feed. Completed portals keep their section visible until you close the drawer.
- **Pills in the main feed** — a clickable "↗ Researcher's portal · 3 messages" at each portal's `created_at`, interleaved with messages by timestamp. Click a historical pill → opens a single-portal focused view. Click a live pill → opens the stack focused on that portal.
- **Escape** closes the drawer; closing clears the `live` flag on all portals (they remain recallable via pills).

### Coordinator grounding
The biggest subtle fix. `getMessagesSince(..., excludeThreaded=true)` was filtering out portal-thread messages, which meant the coordinator couldn't see what its own specialists said. Split semantics with a new `keepPortalThreads` param:
- Main-feed display keeps `excludeThreaded=true, keepPortalThreads=false` (hide everything threaded — portal content lives in the drawer)
- Coordinator prompt paths use `excludeThreaded=true, keepPortalThreads=true` (hide trigger threads but keep portal output so synthesis works)

### Rich content everywhere
Extracted `MessageBody` (blocks + markdown pipeline) so main feed, threads, and portals all render identically. @-mention click handling moved in here too — any surface that uses `MessageBody` gets clickable mentions for free.

### Portal-aware agent instructions
`buildMultiAgentContext` now tells coordinators their delegation output lands in portals (not the main feed) and to synthesize rather than say "see above". Specialists are told their output is read by the coordinator and rich UI blocks aren't supported in portals yet.

## Out of scope (tracked for follow-up phases)

- **2a.1 — Activity streaming into portals**: `agent_progress` SSE already carries `thread_id`; `PortalSection` should subscribe and render tool-call activity inline for "still churning" feedback and stall detection.
- **2b — Action button `target: "thread"`**: second entry point to the same primitive.
- **2c — MCP tool (`open_portal` / `close_portal`)**: agent-driven entry point.
- **2d — Main-thread summary on portal completion**: a summary card in main feed linking back to the portal.
- **UI blocks (action buttons, forms) inside portals**: constraints not sorted yet (where do clicks target?).

## Commits

- `7c89a69` Phase 2a: Delegations drain into the side-drawer portal
- `76e351f` Fix duplicate getThreadMessages export in api.js
- `c785486` Dock AgentPanel as a side panel on desktop
- `cee3a03` Phase 2a polish: pills, stacked drawer, coordinator grounding, MessageBody

## Test plan

- [x] 505/505 unit tests pass, clean `tsc`
- [x] Smoke: single-agent delegation fires `thread_opened`, routes specialist output through portal thread_id, main feed filters it out, `/api/thread-messages` returns it, `thread_closed` fires on completion
- [x] Smoke: parallel delegation (Researcher + Analyst + Writer "say hello") → 3 portals, 3 pills, 3 stacked sections, 3 LIVE badges drop as agents finish, sections persist until drawer closes
- [x] Smoke: coordinator synthesis works — asked "summarize everyone's responses" after parallel delegation and coordinator produces a proper synthesis (previously said "I only see system notifications")
- [x] Browser: historical portal pill click opens single-portal focused view
- [x] Browser: rich markdown in portal messages (confirmed live, but worth one more pass)

## Links

Builds on #91 (Phase 1 retroactive viewer). Closes #90 Phase 2a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)