### PR TITLE
Phase 2a.1: Live tool activity in portal sections (#90)

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -40,6 +40,11 @@ export const lastRunUsage = signal({}); // { [jid]: UsageData } — per-group la
 export const typingStartTime = signal({}); // { [jid]: timestamp } — when typing started
 export const typingAgentName = signal({}); // { [jid]: string } — which agent is typing
 export const agentProgress = signal({}); // { [jid]: { tool, summary, history[] } }
+// Portal-scoped progress shard. Same shape as agentProgress but keyed by
+// thread_id so each PortalSection in the drawer can render its own live
+// tool activity. Also tracks lastEventAt for stall detection.
+// { [thread_id]: { tool, summary, history[], lastEventAt } }
+export const portalProgress = signal({});
 export const activeAgents = signal({}); // { [jid]: string[] } — agent names currently working
 export const workState = signal({}); // { [jid]: WorkStateEvent }
 export const currentWorkState = computed(() => workState.value[selectedJid.value] || null);
@@ -326,6 +331,30 @@ api.onSSE('play_sound', (data) => {
 });
 
 api.onSSE('agent_progress', (data) => {
+  // If this progress carries a thread_id, route it to the portal shard —
+  // the drawer's PortalSection wants to show per-portal tool activity.
+  // Portal events bypass the typingGroups gate; the drawer stays open
+  // across typing flips so we shouldn't drop them.
+  if (data.thread_id) {
+    const prev = portalProgress.value[data.thread_id];
+    const history = prev?.history || [];
+    const updated = [
+      ...history,
+      { tool: data.tool, summary: data.summary, timestamp: data.timestamp },
+    ];
+    if (updated.length > 20) updated.shift();
+    portalProgress.value = {
+      ...portalProgress.value,
+      [data.thread_id]: {
+        tool: data.tool,
+        summary: data.summary,
+        history: updated,
+        lastEventAt: Date.now(),
+      },
+    };
+    // Don't return — also update the chat-jid shard below so the main
+    // typing indicator reflects activity in multi-agent groups.
+  }
   // Drop late-arriving progress events for groups that have already cleared
   // their typing state — prevents the indicator from flashing stale data.
   if (!typingGroups.value[data.jid]) return;

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
-import { agentPanel, portalThreads, selectedJid } from '../app.js';
+import { agentPanel, portalThreads, portalProgress, selectedJid } from '../app.js';
 import * as api from '../api.js';
 import { MessageBody } from './MessageBody.js';
 
@@ -98,6 +98,8 @@ function LiveMessage({ msg }) {
   `;
 }
 
+const STALL_THRESHOLD_MS = 30000;
+
 /** Renders one portal (specialist) as a collapsible section in the stack.
  *  isRunning drives the LIVE badge; sections stay in the stack after the
  *  agent finishes so the user can keep reading. */
@@ -106,6 +108,7 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
   const [historicalMsgs, setHistoricalMsgs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(true);
+  const [now, setNow] = useState(Date.now());
 
   useEffect(() => {
     let cancelled = false;
@@ -134,6 +137,14 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
     }
   }, [focused]);
 
+  // Tick every 2s while running so stall detection can re-render without
+  // waiting for the next progress event.
+  useEffect(() => {
+    if (!isRunning) return;
+    const id = setInterval(() => setNow(Date.now()), 2000);
+    return () => clearInterval(id);
+  }, [isRunning]);
+
   const liveMsgs = portal?.messages || [];
   const seen = new Set(historicalMsgs.map((m) => m.id).filter(Boolean));
   const combined = [
@@ -141,6 +152,13 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
     ...liveMsgs.filter((m) => !m.id || !seen.has(m.id)),
   ];
   const count = combined.length;
+
+  // Per-portal progress feed — shows the agent's tool-call chain live.
+  const progress = portalProgress.value[threadId];
+  const lastEventAt = progress?.lastEventAt || 0;
+  const recentTool = progress?.history?.filter((h) => h.tool && h.tool !== 'text').slice(-1)[0];
+  const stalled =
+    isRunning && lastEventAt > 0 && now - lastEventAt > STALL_THRESHOLD_MS;
 
   return html`
     <section
@@ -153,8 +171,11 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
       >
         <span class="text-[9px] transition-transform ${open ? 'rotate-90' : ''}">\u25B6</span>
         <span class="text-xs font-semibold truncate">${portal.agentName || 'Agent'}</span>
-        ${isRunning && html`
+        ${isRunning && !stalled && html`
           <span class="text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/20 text-accent">live</span>
+        `}
+        ${stalled && html`
+          <span class="text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded bg-err/20 text-err" title="No activity for ${Math.round((now - lastEventAt) / 1000)}s">stalled?</span>
         `}
         <span class="text-[10px] text-txt-muted font-mono ml-auto shrink-0">
           ${count} msg${count !== 1 ? 's' : ''}
@@ -165,12 +186,22 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
           ${loading && combined.length === 0 && html`
             <div class="text-xs text-txt-muted p-2 text-center">Loading...</div>
           `}
-          ${!loading && combined.length === 0 && html`
+          ${!loading && combined.length === 0 && !isRunning && html`
+            <div class="text-xs text-txt-muted p-2 text-center">No messages.</div>
+          `}
+          ${combined.map((m, i) => html`<${LiveMessage} key=${m.id || i} msg=${m} />`)}
+          ${isRunning && recentTool && html`
+            <div class="flex items-start gap-2 py-1 px-2 text-[11px] text-txt-muted">
+              <span class="font-mono text-[10px] text-accent shrink-0 mt-px">${recentTool.tool}</span>
+              <span class="truncate">${recentTool.summary || ''}</span>
+              <span class="typing-dot inline-block ml-auto mt-1" />
+            </div>
+          `}
+          ${isRunning && !recentTool && combined.length === 0 && html`
             <div class="text-xs text-txt-muted p-2 text-center">
               Waiting for agent output... <span class="typing-dot inline-block ml-1" />
             </div>
           `}
-          ${combined.map((m, i) => html`<${LiveMessage} key=${m.id || i} msg=${m} />`)}
         </div>
       `}
     </section>

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -105,6 +105,7 @@ const STALL_THRESHOLD_MS = 30000;
  *  agent finishes so the user can keep reading. */
 function PortalSection({ threadId, portal, focused, isRunning }) {
   const sectionRef = useRef(null);
+  const bodyRef = useRef(null);
   const [historicalMsgs, setHistoricalMsgs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(true);
@@ -160,13 +161,29 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
   const stalled =
     isRunning && lastEventAt > 0 && now - lastEventAt > STALL_THRESHOLD_MS;
 
+  const dismiss = (e) => {
+    e.stopPropagation();
+    const next = { ...portalThreads.value };
+    delete next[threadId];
+    portalThreads.value = next;
+  };
+
+  // Auto-scroll body to bottom when new content arrives, but only if the
+  // user was already at the bottom (don't yank them off their scroll position).
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    if (atBottom) el.scrollTop = el.scrollHeight;
+  }, [combined.length, recentTool?.timestamp]);
+
   return html`
     <section
       ref=${sectionRef}
       class="flex flex-col border border-border rounded-md overflow-hidden ${focused ? 'ring-1 ring-accent/60' : ''}"
     >
-      <button
-        class="flex items-center gap-2 px-3 py-2 bg-bg-3 hover:bg-bg-hover transition-colors text-left cursor-pointer"
+      <div
+        class="flex items-center gap-2 px-3 py-2 bg-bg-3 hover:bg-bg-hover transition-colors cursor-pointer"
         onClick=${() => setOpen(!open)}
       >
         <span class="text-[9px] transition-transform ${open ? 'rotate-90' : ''}">\u25B6</span>
@@ -180,9 +197,18 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
         <span class="text-[10px] text-txt-muted font-mono ml-auto shrink-0">
           ${count} msg${count !== 1 ? 's' : ''}
         </span>
-      </button>
+        <button
+          class="w-5 h-5 flex items-center justify-center rounded text-txt-muted hover:text-err hover:bg-bg-2 transition-colors shrink-0"
+          title="Remove from stack"
+          onClick=${dismiss}
+        >
+          <svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+          </svg>
+        </button>
+      </div>
       ${open && html`
-        <div class="p-2 flex flex-col gap-1.5 bg-bg-2">
+        <div ref=${bodyRef} class="p-2 flex flex-col gap-1.5 bg-bg-2 min-h-[4rem] max-h-[24rem] overflow-y-auto">
           ${loading && combined.length === 0 && html`
             <div class="text-xs text-txt-muted p-2 text-center">Loading...</div>
           `}


### PR DESCRIPTION
## Summary

Each `PortalSection` in the agent drawer now shows its live tool-call activity inline, with a pulse dot while working and a "stalled?" pill if no activity for 30s. Addresses the roadmap note from #92: "is it still churning, or did it stall?"

- **`portalProgress`** — new client-side signal sharding `agent_progress` SSE events by `thread_id` (the `thread_id` was already on the wire since Phase 2a, just unconsumed)
- **Per-section activity row** — latest tool name + summary + pulse dot renders below the message feed in each live section
- **Stall detection** — if a portal is running but no progress event arrives for 30s, the LIVE badge flips to a red "stalled?" pill (with elapsed seconds in the tooltip). Clears on the next event or on `thread_closed`
- **2s re-render tick** while running so stall timing doesn't need another SSE event to update

The main-feed `TypingIndicator` path (chat-jid-scoped `agentProgress`) is unchanged. Portal events route to both shards so nothing regresses.

## Test plan

- [x] Unit tests still pass (505/505), clean `tsc`
- [x] Smoke: parallel tool-heavy delegation → all 3 portal sections show `Bash · ls /workspace/group` with pulse while running, activity clears and LIVE badge drops on completion
- [ ] Smoke: artificially stall a delegation (long Bash) to verify the "stalled?" pill appears after 30s

## Commits

- `a6f55ef` Phase 2a.1: Live tool activity in portal sections

Part of #90. Next up: 2b (action button `target: "thread"`), 2c (MCP tool), 2d (summary on close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)