### PR TITLE
Phase 2b: Action buttons target portal threads (#90)

### DIFF
--- a/container/skills/rich-output/SKILL.md
+++ b/container/skills/rich-output/SKILL.md
@@ -153,7 +153,7 @@ Unified diff display with add/remove line coloring.
 | `filename` | no | File being diffed |
 
 ### action
-Clickable buttons the user can press. Clicking sends `[action: button_id]` as a chat message back to you.
+Clickable buttons the user can press. Clicking sends `[action: button_id]` as a chat message back to you — unless the button targets a portal (see below).
 
 ```json
 { "type": "action", "buttons": [{ "id": "approve", "label": "Approve", "style": "primary" }, { "id": "reject", "label": "Reject", "style": "danger" }, { "id": "skip", "label": "Skip", "style": "default" }] }
@@ -163,8 +163,20 @@ Clickable buttons the user can press. Clicking sends `[action: button_id]` as a 
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `buttons` | yes | Array of `{ id, label, style? }` objects |
+| `buttons` | yes | Array of `{ id, label, style?, target?, target_agent?, action_message? }` objects |
 | `style` | no | `primary` (blue), `danger` (red), `default` (gray) |
+| `target` | no | `"main"` (default — click sends a user message in chat) or `"thread"` (click runs a specialist agent in a side-panel portal instead of cluttering the main feed). Use for "run a focused task" actions like "Review PR #1310" or "Regenerate weekly report". |
+| `target_agent` | required when `target="thread"` | Name of the specialist agent that should handle this action. The portal drains that agent's output. |
+| `action_message` | no | Custom prompt sent to the target agent. Defaults to the button label. Prefer an explicit, specific prompt so the specialist has the context it needs. |
+
+**Portal button example** — dashboard with drill-in actions that don't bury the status report:
+
+```json
+{ "type": "action", "buttons": [
+  { "id": "review_1310", "label": "Review PR #1310", "style": "primary", "target": "thread", "target_agent": "reviewer", "action_message": "Review polaris-ui PR #1310 in detail — check the diff, call out any risky changes, and flag files that look off." },
+  { "id": "skip", "label": "Skip", "style": "default" }
+] }
+```
 
 ### form
 Interactive form for collecting structured input from the user. Renders as labeled fields with a submit button. When submitted, sends a structured `[form: id]...[/form]` message back to you.

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -76,6 +76,16 @@ export interface ChannelOpts {
   ) => void;
   /** Broadcast portal thread completion */
   onThreadClosed?: (originJid: string, threadId: string) => void;
+  /** Trigger a delegation from the UI (e.g. action-button with target:"thread").
+   *  Same mechanism as the MCP tool path — reuses the shared delegation
+   *  handler so both entry points produce identical portal behavior. */
+  onUserDelegation?: (request: {
+    sourceGroup: string;
+    chatJid: string;
+    targetAgent: string;
+    message: string;
+    sourceAgent: string;
+  }) => void;
   /** Reset session for a group (clears SDK session, evicts warm pool) */
   onResetSession?: (groupFolder: string) => Promise<void>;
   /** Get fully discovered agents for a group with runtime metadata */

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1672,6 +1672,47 @@ You do not delegate. If something falls outside your role, say so plainly in you
       return this.json(res, 200, { ok: true, messageId: msg.id });
     }
 
+    // POST /api/action — invoke an action-button with target:"thread".
+    // Mints a portal thread routed to a specific specialist agent, then
+    // reuses the shared delegation machinery via onUserDelegation.
+    if (method === 'POST' && url.pathname === '/api/action') {
+      const body = await this.readBody(req);
+      const { jid, target_agent, label, action_message, sender } = body;
+      if (!jid || !target_agent || !action_message) {
+        return this.json(res, 400, {
+          error: 'jid, target_agent, and action_message are required',
+        });
+      }
+      if (!jid.startsWith('web:')) {
+        return this.json(res, 400, { error: 'jid must start with web:' });
+      }
+      const groups = this.opts.registeredGroups();
+      const group = groups[jid];
+      if (!group) {
+        return this.json(res, 404, { error: 'Group not registered' });
+      }
+      if (!this.opts.onUserDelegation) {
+        return this.json(res, 503, {
+          error: 'Delegation handler not wired on this channel',
+        });
+      }
+      this.opts.onUserDelegation({
+        sourceGroup: group.folder,
+        chatJid: jid,
+        targetAgent: target_agent,
+        message: action_message,
+        // The prompt string "Delegation from X" is surfaced to the
+        // specialist; user-initiated actions read more naturally as
+        // "the user" than as a synthetic identifier.
+        sourceAgent: sender || 'the user',
+      });
+      logger.info(
+        { jid, target_agent, label },
+        'Portal action invoked from web UI',
+      );
+      return this.json(res, 200, { ok: true });
+    }
+
     // GET /api/status — container/queue status + uptime
     if (method === 'GET' && url.pathname === '/api/status') {
       const status = this.opts.getStatus?.() || {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2816,6 +2816,20 @@ async function main(): Promise<void> {
     logger.fatal('No channels connected');
     process.exit(1);
   }
+  // Web channel's action-button click path (target:"thread") needs a way
+  // to invoke the delegation machinery without the MCP tool. channelOpts
+  // was already passed to the channel constructor, but onUserDelegation is
+  // optional — channels opt into it. The adapter routes through the
+  // shared delegationHandler (declared below, after startIpcWatcher setup).
+  channelOpts.onUserDelegation = (req) => {
+    delegationHandler({
+      sourceGroup: req.sourceGroup,
+      chatJid: req.chatJid,
+      targetAgent: req.targetAgent,
+      message: req.message,
+      sourceAgent: req.sourceAgent,
+    });
+  };
 
   // Shared callback: tasks mutated or a run completed. Refreshes per-group
   // task snapshots and nudges the web UI to re-sort the sidebar (used when
@@ -2883,6 +2897,304 @@ async function main(): Promise<void> {
     getMainChatJid,
     onTasksChanged,
   });
+
+  // Delegation handler — invokable from both the IPC MCP tool (coordinator
+  // calls delegate_to_agent) and the web channel (action-button click with
+  // target: "thread"). Same primitive, different entry points.
+  const delegationHandler = (request: {
+    sourceGroup: string;
+    chatJid: string;
+    targetAgent: string;
+    message: string;
+    sourceAgent: string;
+    sourceBatchId?: string;
+    completionPolicy?: 'final_response' | 'retrigger_coordinator';
+  }): void => {
+    const {
+      sourceGroup,
+      chatJid: delegationChatJid,
+      targetAgent,
+      message,
+      sourceAgent,
+      sourceBatchId,
+      completionPolicy,
+    } = request;
+
+    const validation = validateDelegationMessage(message);
+    if (!validation.ok) {
+      logger.warn(
+        {
+          event: 'multi_agent.delegation_rejected',
+          sourceGroup,
+          sourceAgent,
+          targetAgent,
+          sourceBatchId,
+          messageLen: (message ?? '').trim().length,
+          reason: validation.reason,
+        },
+        'Delegation rejected: insufficient message context',
+      );
+      return;
+    }
+
+    const groupJid = Object.keys(registeredGroups).find(
+      (jid) => registeredGroups[jid].folder === sourceGroup,
+    );
+    if (!groupJid) {
+      logger.warn({ sourceGroup, targetAgent }, 'Delegation: group not found');
+      return;
+    }
+    const group = registeredGroups[groupJid];
+    const agents = groupAgents[groupJid] || [];
+    const agent = agents.find((a) => a.name === targetAgent);
+    if (!agent) {
+      logger.warn(
+        { sourceGroup, targetAgent, available: agents.map((a) => a.name) },
+        'Delegation: target agent not found',
+      );
+      return;
+    }
+
+    const chatJid = delegationChatJid || groupJid;
+    const channel = findChannel(channels, chatJid);
+    if (!channel) {
+      logger.warn({ chatJid }, 'Delegation: no channel for JID');
+      return;
+    }
+
+    logger.info(
+      {
+        event: 'multi_agent.delegation_invoked',
+        group: group.name,
+        source: sourceAgent,
+        target: targetAgent,
+        sourceBatchId,
+        messageLen: message.length,
+      },
+      'Processing agent delegation',
+    );
+
+    const savedConfig = group.containerConfig;
+    const delegationTimeout = getCapabilityProfile(
+      agent.runtime,
+    ).delegationTimeoutMs;
+    const taskId = `delegation-${agent.name}-${Date.now()}`;
+    const portalThreadId = `portal-${taskId}`;
+    createThread(
+      portalThreadId,
+      `${group.folder}/${agent.name}`,
+      chatJid,
+      agent.displayName,
+      'portal',
+    );
+    broadcastThreadOpened?.(
+      chatJid,
+      portalThreadId,
+      agent.displayName,
+      'portal',
+      sourceAgent,
+    );
+    queue.enqueueDelegation(
+      chatJid,
+      taskId,
+      async () => {
+        const batchId = sourceBatchId || `delegation-${randomUUID()}`;
+        const lease = beginDeliveryLease(chatJid, batchId);
+        let deliveredToUser = false;
+        group.containerConfig = {
+          ...savedConfig,
+          timeout: Math.min(
+            savedConfig?.timeout || Infinity,
+            delegationTimeout,
+          ),
+        };
+        const multiAgentCtx = buildMultiAgentContext(agent, agents);
+        const recentMessages = getMessagesSince(
+          chatJid,
+          '',
+          ASSISTANT_NAME,
+          MAX_MESSAGES_PER_PROMPT,
+          true,
+        );
+        const conversationCtx = formatMessages(recentMessages, TIMEZONE);
+        const delegationPrompt =
+          conversationCtx +
+          `\n\n--- Delegation from ${sourceAgent} ---\n${message}\n--- End delegation ---\n`;
+        const delegationMessages: StructuredMessage[] = [
+          ...toStructuredMessages(recentMessages),
+          {
+            role: 'user',
+            content: `Delegation from ${sourceAgent}: ${message}`,
+            sender: sourceAgent,
+            timestamp: new Date().toISOString(),
+          },
+        ];
+
+        setActiveAgentName(chatJid, agent.displayName);
+        await channel.setTyping?.(
+          chatJid,
+          true,
+          portalThreadId,
+          agent.displayName,
+        );
+
+        const status = await runAgent(
+          group,
+          delegationPrompt,
+          chatJid,
+          async (result) => {
+            if (result.result) {
+              if (
+                result.textsAlreadyStreamed &&
+                result.textsAlreadyStreamed > 0
+              ) {
+                // Text already delivered via intermediate markers
+              } else {
+                const raw =
+                  typeof result.result === 'string'
+                    ? result.result
+                    : JSON.stringify(result.result);
+                const text = raw
+                  .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+                  .trim();
+                if (text) {
+                  setActiveAgentName(chatJid, agent.displayName);
+                  if (
+                    await deliverAgentMessage(
+                      channel,
+                      chatJid,
+                      text,
+                      lease,
+                      portalThreadId,
+                    )
+                  ) {
+                    deliveredToUser = true;
+                  }
+                }
+              }
+            }
+            if (result.status === 'success') {
+              await channel.setTyping?.(
+                chatJid,
+                false,
+                portalThreadId,
+                agent.displayName,
+              );
+            }
+            if (result.status === 'error') {
+              await channel.setTyping?.(
+                chatJid,
+                false,
+                portalThreadId,
+                agent.displayName,
+              );
+            }
+          },
+          (event) => broadcastProgress(chatJid, event, portalThreadId),
+          async (rawText) => {
+            const text = rawText
+              .replace(/<internal>[\s\S]*?<\/internal>/g, '')
+              .trim();
+            if (!text) return;
+            setActiveAgentName(chatJid, agent.displayName);
+            if (
+              await deliverAgentMessage(
+                channel,
+                chatJid,
+                text,
+                lease,
+                portalThreadId,
+              )
+            ) {
+              deliveredToUser = true;
+            }
+          },
+          agent,
+          true,
+          async (text) => {
+            setActiveAgentName(chatJid, agent.displayName);
+            if (
+              await deliverAgentMessage(
+                channel,
+                chatJid,
+                text,
+                lease,
+                portalThreadId,
+              )
+            ) {
+              deliveredToUser = true;
+            }
+          },
+          batchId,
+          multiAgentCtx || undefined,
+          delegationMessages,
+        );
+
+        group.containerConfig = savedConfig;
+        clearActiveAgentName(chatJid);
+        await channel.setTyping?.(
+          chatJid,
+          false,
+          portalThreadId,
+          agent.displayName,
+        );
+        broadcastThreadClosed?.(chatJid, portalThreadId);
+        if (persistExplicitAgentStatus(chatJid, agent.name, '')) {
+          logger.info(
+            { jid: chatJid, agentName: agent.name },
+            'Cleared agent status after delegation completed',
+          );
+        }
+
+        if (status === 'success') {
+          const resultTraces = evaluateAutomationRules(
+            group.folder,
+            {
+              type: 'agent_result',
+              groupJid: chatJid,
+              groupFolder: group.folder,
+              agentName: agent.name,
+            },
+            agents.map((a) => a.name),
+          );
+          if (resultTraces.length > 0) {
+            await executeAutomationActions(
+              resultTraces,
+              chatJid,
+              group,
+              agents,
+              channel,
+              '',
+            );
+          }
+        }
+
+        const resultNote =
+          status === 'error'
+            ? `[${agent.displayName} was unable to complete the delegated task.]`
+            : deliveredToUser
+              ? `[${agent.displayName} has responded above.]`
+              : `[${agent.displayName} completed but output was superseded by newer context.]`;
+        storeMessage({
+          id: `delegation-result-${Date.now()}`,
+          chat_jid: chatJid,
+          sender: 'system',
+          sender_name: 'System',
+          content: resultNote,
+          timestamp: new Date().toISOString(),
+          is_from_me: false,
+          is_bot_message: false,
+        });
+        logger.info(
+          { group: group.name, target: targetAgent, status },
+          'Delegation complete',
+        );
+      },
+      agent.displayName,
+      completionPolicy !== 'retrigger_coordinator',
+    );
+  };
+
   startIpcWatcher({
     sendMessage: (jid, rawText) => {
       const channel = findChannel(channels, jid);
@@ -3041,322 +3353,7 @@ async function main(): Promise<void> {
         timestamp: new Date().toISOString(),
       });
     },
-    onDelegateToAgent: (request) => {
-      const {
-        sourceGroup,
-        chatJid: delegationChatJid,
-        targetAgent,
-        message,
-        sourceAgent,
-        sourceBatchId,
-        completionPolicy,
-      } = request;
-
-      // Platform-level backstop (#48). Duplicates the check the MCP tool
-      // already applies in the coordinator container — this catches the
-      // case where the container image is stale (pre-validation) and would
-      // otherwise waste a ~30-60s specialist startup on hollow context.
-      const validation = validateDelegationMessage(message);
-      if (!validation.ok) {
-        logger.warn(
-          {
-            event: 'multi_agent.delegation_rejected',
-            sourceGroup,
-            sourceAgent,
-            targetAgent,
-            sourceBatchId,
-            messageLen: (message ?? '').trim().length,
-            reason: validation.reason,
-          },
-          'Delegation rejected: insufficient message context',
-        );
-        return;
-      }
-
-      // Find the group JID from the source folder
-      const groupJid = Object.keys(registeredGroups).find(
-        (jid) => registeredGroups[jid].folder === sourceGroup,
-      );
-      if (!groupJid) {
-        logger.warn(
-          { sourceGroup, targetAgent },
-          'Delegation: group not found',
-        );
-        return;
-      }
-      const group = registeredGroups[groupJid];
-      const agents = groupAgents[groupJid] || [];
-      const agent = agents.find((a) => a.name === targetAgent);
-      if (!agent) {
-        logger.warn(
-          { sourceGroup, targetAgent, available: agents.map((a) => a.name) },
-          'Delegation: target agent not found',
-        );
-        return;
-      }
-
-      const chatJid = delegationChatJid || groupJid;
-      const channel = findChannel(channels, chatJid);
-      if (!channel) {
-        logger.warn({ chatJid }, 'Delegation: no channel for JID');
-        return;
-      }
-
-      logger.info(
-        {
-          event: 'multi_agent.delegation_invoked',
-          group: group.name,
-          source: sourceAgent,
-          target: targetAgent,
-          sourceBatchId,
-          messageLen: message.length,
-        },
-        'Processing agent delegation',
-      );
-
-      // Run the delegation in parallel — delegations bypass per-group
-      // serialization and can run alongside the coordinator and other
-      // delegations. The queue re-triggers the coordinator automatically
-      // when all delegations for a group complete.
-      const savedConfig = group.containerConfig;
-      // Specialist's capability profile dictates how long the host will
-      // wait — fast cloud APIs (Claude) fail fast, slow local runtimes
-      // (CPU-only Ollama) get headroom. See src/model-capabilities.ts.
-      const delegationTimeout = getCapabilityProfile(
-        agent.runtime,
-      ).delegationTimeoutMs;
-      const taskId = `delegation-${agent.name}-${Date.now()}`;
-      // Each delegation gets its own portal thread — the specialist's
-      // output drains into the side panel rather than the main chat.
-      const portalThreadId = `portal-${taskId}`;
-      createThread(
-        portalThreadId,
-        `${group.folder}/${agent.name}`,
-        chatJid,
-        agent.displayName,
-        'portal',
-      );
-      broadcastThreadOpened?.(
-        chatJid,
-        portalThreadId,
-        agent.displayName,
-        'portal',
-        sourceAgent,
-      );
-      queue.enqueueDelegation(
-        chatJid,
-        taskId,
-        async () => {
-          const batchId = sourceBatchId || `delegation-${randomUUID()}`;
-          const lease = beginDeliveryLease(chatJid, batchId);
-          let deliveredToUser = false;
-          group.containerConfig = {
-            ...savedConfig,
-            timeout: Math.min(
-              savedConfig?.timeout || Infinity,
-              delegationTimeout,
-            ),
-          };
-          // Build prompt at execution time (not enqueue time) so conversation
-          // context includes any messages that arrived while queued.
-          const multiAgentCtx = buildMultiAgentContext(agent, agents);
-          const recentMessages = getMessagesSince(
-            chatJid,
-            '',
-            ASSISTANT_NAME,
-            MAX_MESSAGES_PER_PROMPT,
-            true, // include bot messages for full context
-          );
-          const conversationCtx = formatMessages(recentMessages, TIMEZONE);
-          const delegationPrompt =
-            conversationCtx +
-            `\n\n--- Delegation from ${sourceAgent} ---\n${message}\n--- End delegation ---\n`;
-          // For non-Claude runtimes the delegation instruction was silently
-          // dropped by the XML parser (it lives outside <messages>). Inject
-          // it as a synthetic final user message so it actually reaches the
-          // model via the structured path.
-          const delegationMessages: StructuredMessage[] = [
-            ...toStructuredMessages(recentMessages),
-            {
-              role: 'user',
-              content: `Delegation from ${sourceAgent}: ${message}`,
-              sender: sourceAgent,
-              timestamp: new Date().toISOString(),
-            },
-          ];
-
-          setActiveAgentName(chatJid, agent.displayName);
-          await channel.setTyping?.(
-            chatJid,
-            true,
-            portalThreadId,
-            agent.displayName,
-          );
-          // Intermediate TEXT blocks are shown as status in the typing indicator
-
-          const status = await runAgent(
-            group,
-            delegationPrompt,
-            chatJid,
-            async (result) => {
-              if (result.result) {
-                if (
-                  result.textsAlreadyStreamed &&
-                  result.textsAlreadyStreamed > 0
-                ) {
-                  // Text already delivered via intermediate markers
-                } else {
-                  const raw =
-                    typeof result.result === 'string'
-                      ? result.result
-                      : JSON.stringify(result.result);
-                  const text = raw
-                    .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-                    .trim();
-                  if (text) {
-                    // Set agent name right before sending — parallel delegations
-                    // share the same chatJid so we must claim the name each time
-                    setActiveAgentName(chatJid, agent.displayName);
-                    if (
-                      await deliverAgentMessage(
-                        channel,
-                        chatJid,
-                        text,
-                        lease,
-                        portalThreadId,
-                      )
-                    ) {
-                      deliveredToUser = true;
-                    }
-                  }
-                }
-              }
-              // Delegation containers exit on their own (isDelegation skips
-              // the idle loop in agent-runner) — no notifyIdle needed.
-              if (result.status === 'success') {
-                await channel.setTyping?.(
-                  chatJid,
-                  false,
-                  portalThreadId,
-                  agent.displayName,
-                );
-              }
-              if (result.status === 'error') {
-                await channel.setTyping?.(
-                  chatJid,
-                  false,
-                  portalThreadId,
-                  agent.displayName,
-                );
-              }
-            },
-            (event) => broadcastProgress(chatJid, event, portalThreadId),
-            async (rawText) => {
-              const text = rawText
-                .replace(/<internal>[\s\S]*?<\/internal>/g, '')
-                .trim();
-              if (!text) return;
-              setActiveAgentName(chatJid, agent.displayName);
-              if (
-                await deliverAgentMessage(
-                  channel,
-                  chatJid,
-                  text,
-                  lease,
-                  portalThreadId,
-                )
-              ) {
-                deliveredToUser = true;
-              }
-            },
-            agent,
-            true, // isDelegation — use shorter timeout
-            async (text) => {
-              setActiveAgentName(chatJid, agent.displayName);
-              if (
-                await deliverAgentMessage(
-                  channel,
-                  chatJid,
-                  text,
-                  lease,
-                  portalThreadId,
-                )
-              ) {
-                deliveredToUser = true;
-              }
-            },
-            batchId,
-            multiAgentCtx || undefined,
-            delegationMessages,
-          );
-
-          group.containerConfig = savedConfig; // restore original config
-          clearActiveAgentName(chatJid);
-          await channel.setTyping?.(
-            chatJid,
-            false,
-            portalThreadId,
-            agent.displayName,
-          );
-          broadcastThreadClosed?.(chatJid, portalThreadId);
-          if (persistExplicitAgentStatus(chatJid, agent.name, '')) {
-            logger.info(
-              { jid: chatJid, agentName: agent.name },
-              'Cleared agent status after delegation completed',
-            );
-          }
-
-          // Evaluate and execute automation rules on delegation result
-          if (status === 'success') {
-            const resultTraces = evaluateAutomationRules(
-              group.folder,
-              {
-                type: 'agent_result',
-                groupJid: chatJid,
-                groupFolder: group.folder,
-                agentName: agent.name,
-              },
-              agents.map((a) => a.name),
-            );
-            if (resultTraces.length > 0) {
-              await executeAutomationActions(
-                resultTraces,
-                chatJid,
-                group,
-                agents,
-                channel,
-                '',
-              );
-            }
-          }
-
-          // Store a system message so the coordinator sees the result attribution.
-          // The queue re-triggers the coordinator when all delegations complete.
-          const resultNote =
-            status === 'error'
-              ? `[${agent.displayName} was unable to complete the delegated task.]`
-              : deliveredToUser
-                ? `[${agent.displayName} has responded above.]`
-                : `[${agent.displayName} completed but output was superseded by newer context.]`;
-          storeMessage({
-            id: `delegation-result-${Date.now()}`,
-            chat_jid: chatJid,
-            sender: 'system',
-            sender_name: 'System',
-            content: resultNote,
-            timestamp: new Date().toISOString(),
-            is_from_me: false,
-            is_bot_message: false,
-          });
-          logger.info(
-            { group: group.name, target: targetAgent, status },
-            'Delegation complete',
-          );
-        },
-        agent.displayName,
-        completionPolicy !== 'retrigger_coordinator',
-      );
-    },
+    onDelegateToAgent: delegationHandler,
     onSetSubtitle: (jid, subtitle) => {
       // Update DB and broadcast
       const group = registeredGroups[jid];

--- a/web/js/components/blocks/ActionBlock.js
+++ b/web/js/components/blocks/ActionBlock.js
@@ -1,10 +1,39 @@
 import { html } from 'htm/preact';
-import { handleSend } from '../../app.js';
+import { handleSend, selectedJid } from '../../app.js';
+
+async function invokePortalAction(btn, jid) {
+  const res = await fetch('/api/action', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jid,
+      target_agent: btn.target_agent,
+      label: btn.label,
+      action_message:
+        btn.action_message ||
+        btn.prompt ||
+        `[action: ${btn.id}] ${btn.label}`,
+      sender: 'Web User',
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    console.error('Portal action failed:', err);
+  }
+}
 
 export function ActionBlock({ buttons }) {
   if (!buttons || !buttons.length) return null;
 
   const onClick = (btn) => {
+    // target: "thread" routes the click into a portal via /api/action.
+    // Requires target_agent — which specialist should run the work.
+    if (btn.target === 'thread' && btn.target_agent) {
+      const jid = selectedJid.value;
+      if (jid) invokePortalAction(btn, jid);
+      return;
+    }
+    // Default: inject the action text into the chat as a user message.
     handleSend(`[action: ${btn.id}]`);
   };
 


### PR DESCRIPTION
## Summary

Second entry point to the portal primitive built in #92. Dashboards can now emit action buttons that route focused work into a side-panel portal instead of burying the surrounding status report with the follow-up output.

### Schema

Action blocks gain three optional fields:

| Field | Required | Description |
|-------|----------|-------------|
| `target` | no | `"main"` (default — existing behavior) or `"thread"` (portal routing) |
| `target_agent` | yes when `target="thread"` | Which specialist runs the action |
| `action_message` | no | Custom prompt to the target agent; falls back to button label |

Example from the skill docs:

```json
{ "type": "action", "buttons": [
  { "id": "review_1310", "label": "Review PR #1310", "style": "primary",
    "target": "thread", "target_agent": "reviewer",
    "action_message": "Review polaris-ui PR #1310 in detail — check the diff, call out any risky changes, and flag files that look off." },
  { "id": "skip", "label": "Skip", "style": "default" }
] }
```

### Mechanism

- `ActionBlock.js` branches on `target`: portal actions POST to `/api/action` instead of injecting `"[action: id]"` text into chat
- New `POST /api/action` validates, looks up the group, invokes `channelOpts.onUserDelegation` on the web channel
- `onUserDelegation` is wired to the same `delegationHandler` the MCP tool uses — so portal thread creation, `thread_opened`/`thread_closed` SSE, coordinator grounding all reuse existing Phase 2a infrastructure
- The inline `onDelegateToAgent` handler in `startIpcWatcher`'s IPC deps was extracted into a named `delegationHandler` const inside `main()`. No behavior change for the MCP path
- `sourceAgent` for user actions is the sender name (default `"the user"`) so specialists see clean prompt framing

### Parallelism

Matches 2a — each click mints its own portal and enqueues via `GroupQueue.enqueueDelegation`, which already bypasses per-group serialization and caps at `MAX_CONCURRENT_CONTAINERS`. Clicking N buttons spawns up to N concurrent portals; excess queue behind the concurrency cap.

### Test plan

- [x] `npm run build` + `npm test` clean (505/505)
- [x] Smoke: direct `POST /api/action` to web:deep-dive with `target_agent=researcher` → portal created, Researcher ran, response stored with portal thread_id
- [x] Smoke: asked coordinator to emit a portal-action button. Clicked in browser. Portal opened with Researcher running. Confirmed working end-to-end.

## Out of scope (tracked)

- **Option B** (coordinator routes the action itself into a portal, no `target_agent` required) — requires wrapping the coordinator's own output with a thread_id, which is a bigger refactor. Deferred.
- **Button disabled-state** while action is in flight. Currently multiple rapid clicks mint independent parallel portals. Matches the parallelism design but may want a cooldown.
- **Phase 2c** (MCP tool `open_portal`/`close_portal`) and **2d** (main-thread summary on close) remain.

## Commits

- `d6998a8` Phase 2b: Action buttons can target portal threads

Part of #90. Closes Phase 2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)