### PR TITLE
Phase 2c: open_portal MCP tool (#90)

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -910,6 +910,70 @@ Example: delegate_to_agent({ agent: "analyst", message: "Please analyze the thre
   );
 }
 
+// open_portal is available to every agent (solo, coordinator, specialist).
+// Unlike delegate_to_agent (coordinator-only fan-out to teammates),
+// open_portal spins focused side work into a portal drawer — useful for
+// investigations, long-running tool chains, or anything the user would
+// want to watch separately from the main conversation.
+server.tool(
+  'open_portal',
+  `Open a side-panel portal and spin up focused side work inside it. Use for investigations, long tool chains, or anything that would clutter the main thread.
+
+The portal runs a fresh agent container (by default, a new instance of yourself) with the prompt you give. Its output drains to a collapsible section in the side drawer — the user can watch it live or come back to it later via a pill in the main feed. Fire-and-forget: you continue your current turn immediately; the portal runs in parallel.
+
+Use when:
+- You need to do deep tool-call-heavy work and don't want to bury your main reply
+- You want to kick off parallel investigations
+- The user asks for something best shown as a separate focused session
+
+Do NOT use for:
+- Quick answers — put those in your main reply
+- Simple tool calls that fit in one turn
+
+Example: open_portal({ prompt: "Read every file in /workspace/group/research, find the three strongest sources on cricket acoustics, and summarize them.", title: "Cricket acoustics deep-dive" })`,
+  {
+    prompt: z.string().describe('What you want the portal agent to do. Be specific — the portal runs in a fresh container and sees only this prompt plus conversation context.'),
+    target_agent: z.string().optional().describe('Optional: specialist name to handle the work. Defaults to yourself (self-spawn). In multi-agent groups you can target a teammate when their specialty fits.'),
+    title: z.string().optional().describe('Short label for the portal (shown on the pill and section header). Defaults to the target agent name.'),
+  },
+  async (args) => {
+    const selfAgent = process.env.NANOCLAW_AGENT_NAME || 'default';
+    const trimmedPrompt = (args.prompt ?? '').trim();
+    if (trimmedPrompt.length < MIN_DELEGATION_MESSAGE_LENGTH) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text' as const,
+          text: `open_portal rejected: prompt is too short (${trimmedPrompt.length} chars, minimum ${MIN_DELEGATION_MESSAGE_LENGTH}). The portal runs in a fresh container and sees ONLY this prompt. Retry with specific instructions: what to do, any context (paths, IDs), and what output you want back.`,
+        }],
+      };
+    }
+
+    const PORTALS_DIR = path.join(IPC_DIR, 'portals');
+    writeIpcFile(PORTALS_DIR, {
+      type: 'open_portal',
+      targetAgent: args.target_agent || selfAgent,
+      prompt: args.prompt,
+      title: args.title,
+      sourceAgent: selfAgent,
+      sourceBatchId: process.env.NANOCLAW_RUN_BATCH_ID || '',
+      chatJid,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+
+    const who = args.target_agent && args.target_agent !== selfAgent
+      ? args.target_agent
+      : 'a fresh instance of yourself';
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `Portal opened. ${who} is running the work in a side panel; you can continue your turn normally.`,
+      }],
+    };
+  },
+);
+
 // Start the stdio transport
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/agent-discovery.ts
+++ b/src/agent-discovery.ts
@@ -206,6 +206,7 @@ export function buildMultiAgentContext(
       lines.push(
         `You are the coordinator. You handle general questions directly and delegate specialist work.`,
         `Delegation output lands in a side-panel portal — not the main chat. You see each specialist's reply in your own prompt context on your next turn, but the user does NOT see it directly unless they open the portal. Synthesize what specialists said into your own reply to the user; do not say "see above" or assume they read the specialist output.`,
+        `You also have mcp__nanoclaw__open_portal. Use it to spin off your own focused side work (deep investigations, long tool chains) into a portal without cluttering the main thread. open_portal runs fire-and-forget — you continue your turn immediately while the portal runs in parallel. Default target is yourself (self-spawn); pass target_agent to route to a teammate instead.`,
         `For meaningful ongoing work, keep sidebar presence current: use mcp__nanoclaw__set_subtitle for the team-level summary, and use mcp__nanoclaw__set_agent_status for your own row if you have one.`,
         `Set concise, high-signal statuses when work starts ("Reviewing PRs", "Waiting on Scout") and clear them when the work is done.`,
         `To delegate, use the mcp__nanoclaw__delegate_to_agent tool. Valid targets and example invocations:`,
@@ -242,6 +243,7 @@ export function buildMultiAgentContext(
       lines.push(
         `You are a specialist. Focus on your role and respond directly.`,
         `Your reply appears in a side-panel portal the user can watch, and the coordinator reads it in their own context to synthesize the user-facing answer. Write clean, scannable prose the coordinator can quote or compress. Rich UI blocks (action buttons, forms) are not supported in portals yet — stick to text and markdown.`,
+        `You can also call mcp__nanoclaw__open_portal to spin off focused side work (e.g., a deep investigation that would overwhelm your main reply). Fire-and-forget — you continue immediately while the portal runs in parallel. Default is self-spawn; pass target_agent to hand off to a teammate.`,
         `For meaningful ongoing work, set your own sidebar status with mcp__nanoclaw__set_agent_status using a short phrase like "Reviewing flags" or "Drafting summary", then clear it when you are done.`,
         `If work falls outside your expertise, say so in your response — the coordinator will handle routing.`,
         `Your response may be superseded for user delivery if newer context arrives first. Complete the assigned work cleanly anyway; the coordinator will still see that you finished.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2909,7 +2909,7 @@ async function main(): Promise<void> {
     sourceAgent: string;
     sourceBatchId?: string;
     completionPolicy?: 'final_response' | 'retrigger_coordinator';
-  }): void => {
+  }): string | null => {
     const {
       sourceGroup,
       chatJid: delegationChatJid,
@@ -2934,7 +2934,7 @@ async function main(): Promise<void> {
         },
         'Delegation rejected: insufficient message context',
       );
-      return;
+      return null;
     }
 
     const groupJid = Object.keys(registeredGroups).find(
@@ -2942,7 +2942,7 @@ async function main(): Promise<void> {
     );
     if (!groupJid) {
       logger.warn({ sourceGroup, targetAgent }, 'Delegation: group not found');
-      return;
+      return null;
     }
     const group = registeredGroups[groupJid];
     const agents = groupAgents[groupJid] || [];
@@ -2952,14 +2952,14 @@ async function main(): Promise<void> {
         { sourceGroup, targetAgent, available: agents.map((a) => a.name) },
         'Delegation: target agent not found',
       );
-      return;
+      return null;
     }
 
     const chatJid = delegationChatJid || groupJid;
     const channel = findChannel(channels, chatJid);
     if (!channel) {
       logger.warn({ chatJid }, 'Delegation: no channel for JID');
-      return;
+      return null;
     }
 
     logger.info(
@@ -3193,6 +3193,7 @@ async function main(): Promise<void> {
       agent.displayName,
       completionPolicy !== 'retrigger_coordinator',
     );
+    return portalThreadId;
   };
 
   startIpcWatcher({
@@ -3353,7 +3354,22 @@ async function main(): Promise<void> {
         timestamp: new Date().toISOString(),
       });
     },
-    onDelegateToAgent: delegationHandler,
+    onDelegateToAgent: (request) => {
+      delegationHandler(request);
+    },
+    onOpenPortal: (request) => {
+      // open_portal MCP tool: route through the same delegation pipeline.
+      // Defaults to self-spawn (target agent = calling agent) so solo
+      // agents and specialists can spin off focused side work.
+      delegationHandler({
+        sourceGroup: request.sourceGroup,
+        chatJid: request.chatJid,
+        targetAgent: request.targetAgent, // already defaulted to sourceAgent in the MCP tool
+        message: request.prompt,
+        sourceAgent: request.sourceAgent,
+        sourceBatchId: request.sourceBatchId,
+      });
+    },
     onSetSubtitle: (jid, subtitle) => {
       // Update DB and broadcast
       const group = registeredGroups[jid];

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -58,6 +58,15 @@ export interface IpcDeps {
     sourceBatchId?: string;
     completionPolicy?: 'final_response' | 'retrigger_coordinator';
   }) => void;
+  onOpenPortal?: (request: {
+    sourceGroup: string;
+    chatJid: string;
+    targetAgent: string; // defaults to sourceAgent for self-spawn
+    prompt: string;
+    title?: string;
+    sourceAgent: string;
+    sourceBatchId?: string;
+  }) => void;
   onPublishMedia?: (request: {
     sourceGroup: string;
     chatJid: string;
@@ -275,6 +284,67 @@ export function startIpcWatcher(deps: IpcDeps): void {
         logger.error(
           { err, sourceGroup },
           'Error reading IPC delegations directory',
+        );
+      }
+
+      // Process portal-open requests (open_portal MCP tool). Same wire
+      // format as delegations but writes into a separate /portals/ dir
+      // so the handler can distinguish "coordinator fans out" from
+      // "agent spins off side work for itself".
+      const portalsDir = path.join(ipcBaseDir, sourceGroup, 'portals');
+      try {
+        if (fs.existsSync(portalsDir)) {
+          const portalFiles = fs
+            .readdirSync(portalsDir)
+            .filter((f) => f.endsWith('.json'));
+          for (const file of portalFiles) {
+            const filePath = path.join(portalsDir, file);
+            try {
+              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              fs.unlinkSync(filePath);
+              if (
+                data.type === 'open_portal' &&
+                data.targetAgent &&
+                data.prompt
+              ) {
+                if (deps.onOpenPortal) {
+                  deps.onOpenPortal({
+                    sourceGroup,
+                    chatJid: data.chatJid || '',
+                    targetAgent: data.targetAgent,
+                    prompt: data.prompt,
+                    title: data.title,
+                    sourceAgent: data.sourceAgent || 'unknown',
+                    sourceBatchId: data.sourceBatchId || '',
+                  });
+                  logger.info(
+                    {
+                      sourceGroup,
+                      sourceAgent: data.sourceAgent,
+                      targetAgent: data.targetAgent,
+                      title: data.title,
+                    },
+                    'Portal opened via MCP',
+                  );
+                }
+              }
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error processing IPC portal request',
+              );
+              try {
+                fs.unlinkSync(filePath);
+              } catch {
+                /* ignore */
+              }
+            }
+          }
+        }
+      } catch (err) {
+        logger.error(
+          { err, sourceGroup },
+          'Error reading IPC portals directory',
         );
       }
 


### PR DESCRIPTION
## Summary

Third entry point to the portal primitive. Any agent — coordinator, specialist, or solo — can spin off focused side work into a portal via `mcp__nanoclaw__open_portal`. Fire-and-forget: the calling agent's turn continues immediately while the portal runs in parallel.

Default behavior is **self-spawn** (a new container for the calling agent). Pass `target_agent` to route to a teammate instead.

### Why a new tool instead of delegate_to_agent

- `delegate_to_agent` is coordinator-only, and its prompt contract is "hand off to a teammate I know about." Specialists and solo agents can't use it.
- `open_portal` is unconditional. Specialists can kick off deep investigations. Solo agents (no team) can still portal off side work. The semantic framing is "put this in a side panel," which matches user intent.

### Implementation

`open_portal` reuses the Phase 2a delegation pipeline. The whole handler on the host side is:

```ts
onOpenPortal: (request) => {
  delegationHandler({
    sourceGroup: request.sourceGroup,
    chatJid: request.chatJid,
    targetAgent: request.targetAgent, // defaulted to calling agent in the MCP tool
    message: request.prompt,
    sourceAgent: request.sourceAgent,
  });
},
```

`delegationHandler` now returns the minted thread_id so future callers can reference it. Portal thread creation, `thread_opened`/`thread_closed` SSE, drawer routing, coordinator grounding — all Phase 2a infrastructure. No new portal-specific machinery needed.

### Agent-side

New MCP tool written to IPC `/portals/` dir (distinct from `/delegations/` so the host can tell "coordinator fans out" from "agent spins off side work" in logs). Short-prompt guard rejects payloads below the shared `MIN_DELEGATION_MESSAGE_LENGTH` threshold so fresh specialist containers aren't wasted on empty context.

Coordinator and specialist prompts in `buildMultiAgentContext` now mention the tool and when to reach for it ("deep investigations, long tool chains, anything the user would want to watch separately").

## Test plan

- [x] `npm run build` + `npm test` clean (505/505)
- [x] Container rebuilt via `./container/build.sh` + warm pool flushed
- [x] Smoke: asked Researcher to call `open_portal`. Researcher acknowledged in its own portal, and a SECOND portal spawned with a fresh Researcher instance running the requested workspace scan. Output drained to the drawer. Meta-portals work. :)

## Out of scope

- **`close_portal`** and **mid-run output routing switching** — the true "next section goes to a portal" semantic from the original issue — require plumbing a per-batch thread_id routing state through the main-chat agent path. Deferred as Phase 2c.2 if needed; fire-and-forget covers the main use cases.
- **Phase 2d** (main-thread summary on portal close) remains.

## Commits

- `375bc80` Phase 2c: open_portal MCP tool

## Base branch

This PR targets `feat/phase-2b-action-button-portals` (PR #94) for clean review; merge after #94 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)