### PR TITLE
Phase 2d: Portal completion summaries in the main feed (#90)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -703,10 +703,20 @@ export function getThreadsForChat(chatJid: string): ThreadInfo[] {
  * what they render.
  */
 export function getPortalThreadsForChat(chatJid: string): ThreadInfo[] {
+  // Includes message count + preview of the last assistant reply + duration
+  // (last_message_at - created_at) so the main-feed pill can render a
+  // compact summary on page load without a follow-up fetch per portal.
   return db
     .prepare(
       `SELECT t.thread_id, t.agent_jid, t.origin_jid, t.agent_name, t.created_at, t.kind,
-              COUNT(m.id) as reply_count
+              COUNT(m.id) as reply_count,
+              (SELECT content FROM messages
+               WHERE thread_id = t.thread_id AND chat_jid = ?
+                 AND is_bot_message = 1
+               ORDER BY timestamp DESC LIMIT 1) as last_message_preview,
+              (SELECT timestamp FROM messages
+               WHERE thread_id = t.thread_id AND chat_jid = ?
+               ORDER BY timestamp DESC LIMIT 1) as last_message_at
        FROM threads t
        LEFT JOIN messages m ON m.thread_id = t.thread_id AND m.chat_jid = ?
        WHERE t.origin_jid = ?
@@ -714,7 +724,7 @@ export function getPortalThreadsForChat(chatJid: string): ThreadInfo[] {
        GROUP BY t.thread_id
        ORDER BY t.created_at DESC`,
     )
-    .all(chatJid, chatJid) as ThreadInfo[];
+    .all(chatJid, chatJid, chatJid, chatJid) as ThreadInfo[];
 }
 
 export function storeMediaArtifact(artifact: MediaArtifact): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,8 @@ export interface ThreadInfo {
   created_at: string;
   reply_count?: number;
   kind?: 'trigger' | 'portal';
+  last_message_preview?: string;
+  last_message_at?: string;
 }
 
 export interface Agent {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -462,9 +462,21 @@ api.onSSE('thread_closed', (data) => {
   if (!data.thread_id) return;
   const portal = portalThreads.value[data.thread_id];
   if (!portal) return;
+  const duration =
+    portal.openedAt ? Date.now() - portal.openedAt : portal.durationMs;
+  // Snapshot the final assistant reply as the pill's preview line so the
+  // main-feed summary renders even after the section's live buffer clears.
+  const lastAssistant = [...(portal.messages || [])]
+    .reverse()
+    .find((m) => m.role === 'assistant');
   portalThreads.value = {
     ...portalThreads.value,
-    [data.thread_id]: { ...portal, running: false },
+    [data.thread_id]: {
+      ...portal,
+      running: false,
+      durationMs: duration,
+      lastMessagePreview: lastAssistant?.content || portal.lastMessagePreview,
+    },
   };
 });
 
@@ -698,6 +710,12 @@ export async function selectGroup(jid) {
   // drawer — you see pills inline and click one to inspect it.
   const portalsByThread = {};
   for (const t of portalData.threads || []) {
+    const closedAt =
+      t.last_message_at && t.last_message_at !== t.created_at
+        ? new Date(t.last_message_at).getTime()
+        : null;
+    const durationMs =
+      closedAt ? closedAt - new Date(t.created_at).getTime() : null;
     portalsByThread[t.thread_id] = {
       kind: 'portal',
       jid,
@@ -707,7 +725,10 @@ export async function selectGroup(jid) {
       openedAt: new Date(t.created_at).getTime(),
       createdAt: t.created_at,
       replyCount: t.reply_count || 0,
+      lastMessagePreview: t.last_message_preview || null,
+      durationMs,
       live: false,
+      running: false,
     };
   }
   // Preserve live portals from this session even if DB doesn't have them yet.

--- a/web/js/components/PortalPill.js
+++ b/web/js/components/PortalPill.js
@@ -5,8 +5,6 @@ export function openPortalInDrawer(threadId) {
   const group = selectedGroup.value;
   if (!group) return;
   const portal = portalThreads.value[threadId];
-  // Live portals open in the "portals" stack (focused on the clicked one);
-  // historical portals open solo in a single-portal view.
   if (portal?.live) {
     agentPanel.value = {
       mode: 'portals',
@@ -22,26 +20,68 @@ export function openPortalInDrawer(threadId) {
   }
 }
 
+function formatDuration(ms) {
+  if (!ms || ms < 0) return '';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
+
+// Pull a scannable one-liner from the final assistant reply.
+function previewLine(text) {
+  if (!text) return '';
+  // First non-empty line, stripped of markdown headers/bullets.
+  const line = text
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0) || '';
+  return line.replace(/^#+\s*/, '').replace(/^[-*]\s+/, '').slice(0, 120);
+}
+
 export function PortalPill({ threadId }) {
   const portal = portalThreads.value[threadId];
   if (!portal) return null;
 
   const count = portal.messages.length || portal.replyCount || 0;
-  const subtitle = portal.sourceAgent
-    ? `delegated by ${portal.sourceAgent}`
-    : count
-      ? `${count} message${count !== 1 ? 's' : ''}`
-      : 'running...';
+  const isRunning = !!portal.running;
+
+  // Preview: prefer the live last-message if we have one, else server summary
+  const lastLive = portal.messages?.[portal.messages.length - 1]?.content;
+  const preview = previewLine(lastLive || portal.lastMessagePreview || '');
+
+  // Duration: live portals compute against "now"; done portals use durationMs from server
+  let duration = '';
+  if (isRunning && portal.openedAt) {
+    duration = formatDuration(Date.now() - portal.openedAt);
+  } else if (portal.durationMs) {
+    duration = formatDuration(portal.durationMs);
+  }
+
+  const icon = isRunning ? '\u2197' : '\u2713';
+  const iconColor = isRunning ? 'text-accent' : 'text-green-400';
 
   return html`
     <button
-      class="self-start flex items-center gap-2 px-3 py-1.5 rounded-full bg-bg-3 border border-border text-[11px] text-txt-2 hover:border-accent hover:text-accent transition-colors cursor-pointer max-w-[85%]"
+      class="self-start flex flex-col gap-1 px-3 py-2 rounded-xl bg-bg-3 border border-border text-left hover:border-accent transition-colors cursor-pointer max-w-[85%] w-fit group"
       onClick=${() => openPortalInDrawer(threadId)}
-      title="Open portal"
+      title=${isRunning ? 'Open live portal' : 'Reopen portal'}
     >
-      <span class="text-accent">\u2197</span>
-      <span class="font-medium truncate">${portal.agentName || 'Agent'}'s portal</span>
-      <span class="text-txt-muted truncate">· ${subtitle}</span>
+      <div class="flex items-center gap-2 text-[11px]">
+        <span class="${iconColor} text-sm leading-none">${icon}</span>
+        <span class="font-semibold text-txt">${portal.agentName || 'Agent'}</span>
+        <span class="text-txt-muted">
+          ${isRunning ? 'running' : `${count} msg${count !== 1 ? 's' : ''}`}
+          ${duration ? ` \u00B7 ${duration}` : ''}
+        </span>
+      </div>
+      ${preview && html`
+        <div class="text-[11px] text-txt-2 line-clamp-2 break-words font-normal leading-snug">
+          ${preview}
+        </div>
+      `}
     </button>
   `;
 }


### PR DESCRIPTION
## Summary

The final piece of #90. When a portal completes, the main-thread pill evolves from a minimal "running" indicator into a rich summary card with the agent's name, a check mark, message count, duration, and a preview line from the specialist's final reply.

**Before (Phase 2a):**
```
↗ Researcher's portal · 1 messages
```

**After (2d):**
```
live:  ↗ Researcher · running · 12.3s
done:  ✓ Researcher · 1 msg · 14.1s
       Pick: research-cricket-sounds.md — the scraper data on mole crickets...
```

## Implementation

- `getPortalThreadsForChat` returns `last_message_preview` (most recent assistant reply) and `last_message_at` so pills render full summaries on page load with no extra fetch per portal
- `PortalPill` redesigned as a richer two-line card — header with state icon/name/metadata, optional preview line clamped to 2 lines
- `thread_closed` SSE handler snapshots the final assistant message and computes `durationMs` client-side so the pill updates immediately on completion (doesn't wait for a reload)
- `selectGroup`'s portal-load path hydrates `durationMs` and `lastMessagePreview` from the server; live-portal buffers from this session are preserved during merge

## Test plan

- [x] `npm run build` + `npm test` clean (505/505)
- [x] Smoke: 3-way parallel research sprint. Pills transitioned live → done in real time with accurate per-specialist previews, and the coordinator's synthesis landed in the main feed. 
- [x] User confirmed: "Beautiful."

## Phase 2 complete

This closes #90's full arc:

- **2a** (PR #92) — Delegations drain into the side-drawer portal
- **2a.1** (PR #93) — Live tool activity in portal sections  
- **2b** (PR #94) — Action buttons can target portal threads
- **2c** (PR #95) — `open_portal` MCP tool
- **2d** (this PR) — Portal completion summaries

Phase 3+ ideas (parked, not scheduled):
- Mid-run output routing switch (`close_portal`, "next section goes to a portal")
- UI blocks inside portals (action buttons, forms)
- Button disabled-state during in-flight actions
- Cross-portal references / linking

## Commits

- `2d8f773` Phase 2d: Portal completion summaries in the main feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)