### PR TITLE
Follow-up: portal persistence + polish (never landed on main)

### DIFF
--- a/scripts/verify-portal-persistence.mjs
+++ b/scripts/verify-portal-persistence.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Verify panel persistence: open a portal, reload, confirm it's still in the stack.
+import { chromium } from 'playwright';
+
+const URL = process.env.URL || 'http://localhost:3456';
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+const page = await ctx.newPage();
+
+await page.goto(URL, { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(1500);
+await page.evaluate(() => localStorage.setItem('clawdad-selected-jid', 'web:deep-dive'));
+await page.reload({ waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(2500);
+
+// Clear any lingering panel state so we start clean
+await page.evaluate(() => localStorage.removeItem('clawdad-portal-panel-state'));
+await page.reload({ waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(2000);
+
+console.log('STEP 1: fire a portal action');
+await page.evaluate(() => fetch('/api/action', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    jid: 'web:deep-dive',
+    target_agent: 'writer',
+    label: 'Persistence test',
+    action_message: 'Reply with exactly three sentences about crickets. Short.',
+  }),
+}));
+
+// Wait for portal section to appear
+await page.waitForSelector('section', { timeout: 20_000 });
+await page.waitForTimeout(10_000); // give the delegation time to finish
+
+const afterOpen = await page.evaluate(() => ({
+  panelState: localStorage.getItem('clawdad-portal-panel-state'),
+  drawerPresent: !!document.querySelector('aside .portal-scroll'),
+  sectionCount: document.querySelectorAll('section').length,
+  agentPanelMode: (() => {
+    // Probe the mode by looking at the drawer header text
+    const h = document.querySelector('aside h3');
+    return h?.textContent?.trim();
+  })(),
+}));
+console.log('after open:', JSON.stringify(afterOpen, null, 2));
+
+console.log('\nSTEP 2: reload page');
+await page.reload({ waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(2500);
+
+const afterReload = await page.evaluate(() => ({
+  panelStateAfter: localStorage.getItem('clawdad-portal-panel-state'),
+  drawerPresent: !!document.querySelector('aside .portal-scroll'),
+  sectionCount: document.querySelectorAll('section').length,
+  header: document.querySelector('aside h3')?.textContent?.trim(),
+}));
+console.log('after reload:', JSON.stringify(afterReload, null, 2));
+
+const pass = afterReload.drawerPresent && afterReload.sectionCount >= 1;
+console.log('\nRESULT:', pass ? 'PASS ✓' : 'FAIL ✗');
+await browser.close();
+process.exit(pass ? 0 : 1);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2,6 +2,11 @@ import { render } from 'preact';
 import { signal, computed } from 'preact/signals';
 import { html } from 'htm/preact';
 import * as api from './api.js';
+import {
+  loadPortalStateFor,
+  addLiveThreadForJid,
+  setDrawerStateFor,
+} from './portal-persistence.js';
 import { playNotification, TONES, isMuted } from './sounds.js';
 import { App } from './components/App.js';
 import { showAchievementToast } from './components/blocks/AchievementToast.js';
@@ -434,23 +439,26 @@ api.onSSE('thread_opened', (data) => {
       openedAt: now,
       createdAt: nowIso,
       replyCount: 0,
-      live: true, // in-session — shows in drawer stack until drawer is closed
-      running: true, // actively running — drives the LIVE badge
+      live: true,
+      running: true,
     },
   };
-  // New live portal — always switch the drawer to the portals stack and
-  // focus on the new thread. If the user was inspecting a historical
-  // single portal, live activity takes precedence (they can click a pill
-  // to get back). If the drawer is on a retroactive transcript view
-  // (runId), leave it alone.
+  // Persist the new portal as live for this jid so a refresh keeps it in
+  // the stack.
+  addLiveThreadForJid(data.jid, data.thread_id);
+
+  // New live portal — switch the drawer to the portals stack and focus.
+  // Retroactive transcript views (runId mode) are left alone.
   if (data.jid === selectedJid.value && folder) {
     const cur = agentPanel.value;
     if (!cur || cur.mode === 'portals' || cur.mode === 'portal-single') {
-      agentPanel.value = {
+      const next = {
         mode: 'portals',
         groupFolder: folder,
         focusedThreadId: data.thread_id,
       };
+      agentPanel.value = next;
+      setDrawerStateFor(data.jid, next);
     }
   }
 });
@@ -705,10 +713,11 @@ export async function selectGroup(jid) {
   threadTyping.value = {};
 
   // Build portal index scoped to this chat. Portals loaded from the server
-  // power the pills in the main feed (persistent recall); only portals
-  // opened live in the current session (live: true) render in the drawer
-  // stack. That way a chat with 16 historical portals doesn't flood the
-  // drawer — you see pills inline and click one to inspect it.
+  // power the pills in the main feed (persistent recall); whether each one
+  // lives in the drawer stack is driven by per-jid persisted state so
+  // refreshing or switching groups doesn't lose the user's working panel.
+  const persisted = loadPortalStateFor(jid);
+  const liveSet = new Set(persisted.liveThreadIds);
   const portalsByThread = {};
   for (const t of portalData.threads || []) {
     const closedAt =
@@ -729,16 +738,15 @@ export async function selectGroup(jid) {
       replyCount: t.reply_count || 0,
       lastMessagePreview: t.last_message_preview || null,
       durationMs,
-      live: false,
+      live: liveSet.has(t.thread_id), // restored from persisted state
       running: false,
     };
   }
-  // Preserve live portals from this session even if DB doesn't have them yet.
+  // Preserve in-flight portals from this session that may not be in the DB yet.
   for (const [tid, existing] of Object.entries(portalThreads.value)) {
     if (existing.jid === jid && existing.live && !portalsByThread[tid]) {
       portalsByThread[tid] = existing;
     } else if (existing.jid === jid && existing.live && portalsByThread[tid]) {
-      // DB row exists AND it's the live session portal — preserve live flag
       portalsByThread[tid] = {
         ...portalsByThread[tid],
         ...existing,
@@ -747,6 +755,25 @@ export async function selectGroup(jid) {
     }
   }
   portalThreads.value = portalsByThread;
+
+  // Restore the drawer state for this jid (open + mode + focus). If this
+  // group had a drawer open last time you were in it, reopen to the same
+  // portal or stack.
+  const currentPanel = agentPanel.value;
+  const currentGroupFolder = groups.value.find((g) => g.jid === jid)?.folder;
+  if (persisted.drawer && currentGroupFolder) {
+    agentPanel.value = {
+      ...persisted.drawer,
+      groupFolder: currentGroupFolder,
+    };
+  } else if (
+    currentPanel &&
+    (currentPanel.mode === 'portals' || currentPanel.mode === 'portal-single')
+  ) {
+    // Previous group's drawer was open but this group has no persisted state —
+    // close the drawer rather than leaving it pointing at stale content.
+    agentPanel.value = null;
+  }
 }
 
 export async function handleSend(content) {

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -184,7 +184,7 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
   return html`
     <section
       ref=${sectionRef}
-      class="flex flex-col border border-border rounded-md overflow-hidden ${focused ? 'ring-1 ring-accent/60' : ''}"
+      class="shrink-0 flex flex-col border border-border rounded-md overflow-hidden ${focused ? 'ring-1 ring-accent/60' : ''}"
     >
       <div
         class="flex items-center gap-2 px-3 py-2 bg-bg-3 hover:bg-bg-hover transition-colors cursor-pointer"
@@ -214,7 +214,7 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
         </button>
       </div>
       ${open && html`
-        <div class="portal-scroll p-2 flex flex-col gap-1.5 bg-bg-2" style="min-height: 4rem; max-height: 40rem; overflow-y: scroll;">
+        <div class="portal-scroll p-2 flex flex-col gap-1.5 bg-bg-2" style="min-height: 4rem; max-height: 27rem; overflow-y: scroll;">
           ${loading && combined.length === 0 && html`
             <div class="text-xs text-txt-muted p-2 text-center">Loading...</div>
           `}

--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -3,6 +3,10 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import { agentPanel, portalThreads, portalProgress, selectedJid } from '../app.js';
 import * as api from '../api.js';
 import { MessageBody } from './MessageBody.js';
+import {
+  removeLiveThreadForJid,
+  setDrawerStateFor,
+} from '../portal-persistence.js';
 
 function formatTime(ts) {
   if (!ts) return '';
@@ -166,9 +170,15 @@ function PortalSection({ threadId, portal, focused, isRunning }) {
 
   const dismiss = (e) => {
     e.stopPropagation();
-    const next = { ...portalThreads.value };
-    delete next[threadId];
-    portalThreads.value = next;
+    const portalNow = portalThreads.value[threadId];
+    if (!portalNow) return;
+    // Dismissing removes from the drawer stack but KEEPS the portal in
+    // portalThreads so the pill in the main feed still works for recall.
+    portalThreads.value = {
+      ...portalThreads.value,
+      [threadId]: { ...portalNow, live: false },
+    };
+    removeLiveThreadForJid(portalNow.jid, threadId);
   };
 
   return html`
@@ -368,17 +378,13 @@ function RetroactivePanel({ state }) {
 }
 
 function closeDrawer() {
-  // Closing the drawer clears the "live" flag on all portals — they stay
-  // in portalThreads for pill recall but drop out of the stack. The next
-  // time the user opens the drawer (via pill click or new thread_opened),
-  // the stack starts fresh.
-  const portals = portalThreads.value;
-  const cleared = {};
-  for (const [tid, p] of Object.entries(portals)) {
-    cleared[tid] = p.live ? { ...p, live: false, running: false } : p;
-  }
-  portalThreads.value = cleared;
+  // Close = "out of sight for now", NOT "dismiss." Live flags stay on
+  // portalThreads so reopening (or refreshing, or switching back to this
+  // group) brings the same stack back. Explicit per-section X is how the
+  // user removes things from the stack.
+  const jid = selectedJid.value;
   agentPanel.value = null;
+  if (jid) setDrawerStateFor(jid, null);
 }
 
 function CloseButton() {

--- a/web/js/components/PortalPill.js
+++ b/web/js/components/PortalPill.js
@@ -1,23 +1,24 @@
 import { html } from 'htm/preact';
-import { agentPanel, portalThreads, selectedGroup } from '../app.js';
+import { agentPanel, portalThreads, selectedGroup, selectedJid } from '../app.js';
+import { setDrawerStateFor } from '../portal-persistence.js';
 
 export function openPortalInDrawer(threadId) {
   const group = selectedGroup.value;
   if (!group) return;
   const portal = portalThreads.value[threadId];
-  if (portal?.live) {
-    agentPanel.value = {
-      mode: 'portals',
-      groupFolder: group.folder,
-      focusedThreadId: threadId,
-    };
-  } else {
-    agentPanel.value = {
-      mode: 'portal-single',
-      groupFolder: group.folder,
-      threadId,
-    };
-  }
+  const next = portal?.live
+    ? {
+        mode: 'portals',
+        groupFolder: group.folder,
+        focusedThreadId: threadId,
+      }
+    : {
+        mode: 'portal-single',
+        groupFolder: group.folder,
+        threadId,
+      };
+  agentPanel.value = next;
+  setDrawerStateFor(selectedJid.value, next);
 }
 
 function formatDuration(ms) {

--- a/web/js/portal-persistence.js
+++ b/web/js/portal-persistence.js
@@ -1,0 +1,71 @@
+// Per-jid portal panel state persistence.
+//
+// What we store, keyed by chat jid:
+//   - liveThreadIds: portals currently "in the stack" for this chat
+//   - drawer: { mode, focusedThreadId?, threadId? } or null when closed
+//
+// What this buys:
+//   - Refresh restores the drawer and its stack
+//   - Switching groups remembers each group's panel state independently
+//   - Closing the drawer hides it but keeps live flags (out of sight, not
+//     out of mind). Explicit dismiss (section X) removes from live.
+
+const KEY = 'clawdad-portal-panel-state';
+
+function readAll() {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(state) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(state));
+  } catch {
+    /* quota / private mode — silently degrade */
+  }
+}
+
+export function loadPortalStateFor(jid) {
+  if (!jid) return { liveThreadIds: [], drawer: null };
+  const all = readAll();
+  const entry = all[jid] || {};
+  return {
+    liveThreadIds: Array.isArray(entry.liveThreadIds) ? entry.liveThreadIds : [],
+    drawer: entry.drawer || null,
+  };
+}
+
+export function savePortalStateFor(jid, patch) {
+  if (!jid) return;
+  const all = readAll();
+  const current = all[jid] || { liveThreadIds: [], drawer: null };
+  all[jid] = { ...current, ...patch };
+  writeAll(all);
+}
+
+export function addLiveThreadForJid(jid, threadId) {
+  if (!jid || !threadId) return;
+  const { liveThreadIds } = loadPortalStateFor(jid);
+  if (liveThreadIds.includes(threadId)) return;
+  savePortalStateFor(jid, { liveThreadIds: [...liveThreadIds, threadId] });
+}
+
+export function removeLiveThreadForJid(jid, threadId) {
+  if (!jid || !threadId) return;
+  const { liveThreadIds } = loadPortalStateFor(jid);
+  if (!liveThreadIds.includes(threadId)) return;
+  savePortalStateFor(jid, {
+    liveThreadIds: liveThreadIds.filter((t) => t !== threadId),
+  });
+}
+
+export function setDrawerStateFor(jid, drawer) {
+  if (!jid) return;
+  savePortalStateFor(jid, { drawer: drawer || null });
+}


### PR DESCRIPTION
## Why this exists

PR #105 (\"Portal panel persistence\") showed as merged in the GitHub UI, but its commits never reached \`main\`.

What actually happened:
- PR #105 was stacked on top of PR #104 (\`base: fix/portal-panel-scroll\`) for clean review.
- PR #104 merged to main at 14:21 UTC.
- PR #105 merged at 14:37 UTC — but the merge target was still \`fix/portal-panel-scroll\`, not \`main\`. So the persistence commits went to that now-orphaned branch instead of flowing into main with #104.

Result: main got the scroll fix, not the persistence feature.

This PR re-applies the two commits onto a fresh branch off main.

## What lands

From PR #105 (unchanged):
- \`web/js/portal-persistence.js\` — localStorage read/write helpers
- Panel state (drawer open + live thread IDs) persisted per-jid
- Close drawer ≠ dismiss; section X = explicit dismiss
- Group switch restores that group's panel state
- \`scripts/verify-portal-persistence.mjs\` Playwright verification

From the follow-on polish commit (also never on main):
- \`shrink-0\` on each portal section (fixes collapse-squish when one section is collapsed and the stack would otherwise compress items to fit)
- Section max-height: 40rem → 27rem (~1/3 reduction so multiple portals breathe)

## Test plan

- [x] \`npm run build\` clean
- [x] 505/505 tests pass
- [ ] Re-run \`scripts/verify-portal-persistence.mjs\` after merge

Lesson for next time stacked PRs come up: don't rely on GitHub's \"merged\" state when the base branch isn't main — either rebase onto main before merging #105, or merge the stack bottom-up so the stacked PR's base auto-advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)