### PR TITLE
Fix #107: portal output lost via send_message MCP tool

### DIFF
--- a/container/agent-runner/src/claude-runtime.ts
+++ b/container/agent-runner/src/claude-runtime.ts
@@ -30,6 +30,7 @@ interface ContainerInputLike {
   systemContext?: string;
   achievements?: { id: string; name: string; description: string }[];
   runtime?: AgentRuntimeConfig;
+  portalThreadId?: string;
 }
 
 interface SessionEntry {
@@ -471,6 +472,8 @@ export class ClaudeCodeRuntime implements RuntimeSession {
               NANOCLAW_ACHIEVEMENTS: JSON.stringify(
                 this.options.containerInput.achievements || [],
               ),
+              NANOCLAW_PORTAL_THREAD_ID:
+                this.options.containerInput.portalThreadId || '',
             },
           },
           ollama: {

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -53,6 +53,10 @@ interface ContainerInput {
   runtime?: AgentRuntimeConfig;
   constraints?: RuntimeTurnConstraints;
   achievements?: { id: string; name: string; description: string }[];
+  // Portal routing (host-side issue #107). When set, send_message-style
+  // tools tag their IPC payloads with this thread_id so the host routes
+  // them to the side-panel portal instead of the main feed.
+  portalThreadId?: string;
 }
 
 interface UsageData {

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -87,6 +87,10 @@ server.tool(
     sender: z.string().optional().describe('Your role/identity name (e.g. "Researcher"). When set, messages appear from a dedicated bot in Telegram.'),
   },
   async (args) => {
+    // If this run is portal-scoped (delegation/action button/open_portal),
+    // tag the message so the host routes it to the side panel instead of
+    // the main feed. Empty env var = main-feed message (#107).
+    const portalThreadId = process.env.NANOCLAW_PORTAL_THREAD_ID || '';
     const data: Record<string, string | undefined> = {
       type: 'message',
       chatJid,
@@ -95,6 +99,7 @@ server.tool(
       groupFolder,
       agentId: process.env.NANOCLAW_AGENT_ID || undefined,
       sessionId: process.env.NANOCLAW_SESSION_ID || undefined,
+      threadId: portalThreadId || undefined,
       timestamp: new Date().toISOString(),
     };
 

--- a/container/agent-runner/src/ollama-runtime.ts
+++ b/container/agent-runner/src/ollama-runtime.ts
@@ -78,6 +78,7 @@ interface ContainerInputLike {
   systemContext?: string;
   assistantName?: string;
   achievements?: unknown[];
+  portalThreadId?: string;
 }
 
 /**
@@ -99,6 +100,9 @@ function mcpServerEnv(
     NANOCLAW_CAN_DELEGATE: containerInput.canDelegate ? '1' : '0',
     NANOCLAW_MAIN_JID: containerInput.mainChatJid || '',
     NANOCLAW_ACHIEVEMENTS: JSON.stringify(containerInput.achievements || []),
+    // When set, IPC-driven tools (e.g. send_message) tag outputs so the
+    // host can route them to the side-panel portal instead of main feed.
+    NANOCLAW_PORTAL_THREAD_ID: containerInput.portalThreadId || '',
   };
 }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -78,6 +78,10 @@ export interface ContainerInput {
   constraints?: RuntimeTurnConstraints; // per-turn safety rails (maxTurns, disallowedTools)
   systemContext?: string; // multi-agent context injected into systemPrompt.append (survives compaction)
   achievements?: { id: string; name: string; description: string }[];
+  // When set, this run is draining into a side-panel portal. Tools (esp.
+  // send_message via IPC) tag their outputs with this thread_id so they
+  // route to the portal instead of leaking to the main feed (#107).
+  portalThreadId?: string;
   // Optional positive allowlist over container/skills/*. Undefined = copy
   // every global skill (backward compat). Empty array = copy none.
   // See Phase 3 of #74 / #42.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1705,6 +1705,7 @@ async function runAgent(
   runBatchId?: string,
   systemContext?: string,
   messages?: StructuredMessage[],
+  portalThreadId?: string,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
   const agentId = agent?.id || `${group.folder}/${DEFAULT_AGENT_NAME}`;
@@ -2115,6 +2116,7 @@ async function runAgent(
         systemContext,
         skillsAllowlist: agent?.skills,
         achievements: getAchievementsForContainer(),
+        portalThreadId,
       };
 
       const handle = await spawnContainer(group, containerInput);
@@ -2193,6 +2195,7 @@ async function runAgent(
       systemContext,
       skillsAllowlist: agent?.skills,
       achievements: getAchievementsForContainer(),
+      portalThreadId,
     };
 
     //
@@ -3071,12 +3074,13 @@ async function main(): Promise<void> {
           delegationPrompt,
           chatJid,
           async (result) => {
+            const alreadyStreamed =
+              !!result.textsAlreadyStreamed && result.textsAlreadyStreamed > 0;
             if (result.result) {
-              if (
-                result.textsAlreadyStreamed &&
-                result.textsAlreadyStreamed > 0
-              ) {
-                // Text already delivered via intermediate markers
+              if (alreadyStreamed) {
+                // Text already delivered via intermediate markers / tools
+                // (the deliveredViaTools path on Ollama, or TEXT markers
+                // on Claude). Don't redeliver.
               } else {
                 const raw =
                   typeof result.result === 'string'
@@ -3100,6 +3104,12 @@ async function main(): Promise<void> {
                   }
                 }
               }
+            } else if (alreadyStreamed) {
+              // result is null but the agent did stream via tools (Ollama
+              // tool-capable path). The send_message tool now carries the
+              // portalThreadId in its IPC payload, so output already
+              // routed to the portal — count as delivered.
+              deliveredToUser = true;
             }
             if (result.status === 'success') {
               await channel.setTyping?.(
@@ -3156,6 +3166,7 @@ async function main(): Promise<void> {
           batchId,
           multiAgentCtx || undefined,
           delegationMessages,
+          portalThreadId,
         );
 
         group.containerConfig = savedConfig;
@@ -3224,7 +3235,7 @@ async function main(): Promise<void> {
   };
 
   startIpcWatcher({
-    sendMessage: (jid, rawText) => {
+    sendMessage: (jid, rawText, threadId) => {
       const channel = findChannel(channels, jid);
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       // Always strip <internal> tags — agents use these for reasoning
@@ -3245,7 +3256,9 @@ async function main(): Promise<void> {
           ? stripped
           : formatOutbound(stripped, channel.name as ChannelType);
       if (!text) return Promise.resolve();
-      return channel.sendMessage(jid, text).then(() => {});
+      // threadId routes the message into a side-panel portal when set
+      // (#107 — Ollama tool-capable agents in delegations).
+      return channel.sendMessage(jid, text, threadId).then(() => {});
     },
     registeredGroups: () => registeredGroups,
     registerGroup,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -13,7 +13,7 @@ import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
 
 export interface IpcDeps {
-  sendMessage: (jid: string, text: string) => Promise<void>;
+  sendMessage: (jid: string, text: string, threadId?: string) => Promise<void>;
   registeredGroups: () => Record<string, RegisteredGroup>;
   registerGroup: (jid: string, group: RegisteredGroup) => void;
   syncGroups: (force: boolean) => Promise<void>;
@@ -130,9 +130,17 @@ export function startIpcWatcher(deps: IpcDeps): void {
                   (targetGroup && targetGroup.folder === sourceGroup) ||
                   targetIsMain
                 ) {
-                  await deps.sendMessage(data.chatJid, data.text);
+                  await deps.sendMessage(
+                    data.chatJid,
+                    data.text,
+                    data.threadId || undefined,
+                  );
                   logger.info(
-                    { chatJid: data.chatJid, sourceGroup },
+                    {
+                      chatJid: data.chatJid,
+                      sourceGroup,
+                      threadId: data.threadId || undefined,
+                    },
                     'IPC message sent',
                   );
                 } else {


### PR DESCRIPTION
## Summary

When an agent inside a delegation called the \`send_message\` MCP tool, its messages went through IPC and landed in the main chat feed instead of the portal — there was no \`thread_id\` on the wire. Most visible on Ollama tool-capable agents (which often deliver via tools and return empty \`fullText\`), but anything using \`send_message\` inside a delegation hit it.

## Two coupled bugs

### Bug 1 — no \`portalThreadId\` on the wire

Container env vars carried \`chat_jid\`, agent name, batch id, etc., but not the thread the run was draining into. The MCP \`send_message\` tool wrote messages to IPC without a \`thread_id\`, and the host's IPC sendMessage handler forwarded them to the main feed.

### Bug 2 — falsy \`result.result\` skipped delivery for tool-capable Ollama

When Ollama's tool-capable runtime delivered everything via tools and returned empty \`fullText\`, \`buildResultEvent\` produced \`result: null, textsAlreadyStreamed: 1\`. The delegation handler's \`if (result.result)\` guard then skipped the entire delivery block — and because of bug 1, what *was* delivered via \`send_message\` had leaked to main. With bug 1 fixed, the falsy-result case is no longer a leak; we mark \`deliveredToUser = true\` so the coordinator's result-note reflects \"responded\" rather than \"superseded\".

## Threading

- \`ContainerInput.portalThreadId\` added on host + agent-runner (and both \`ContainerInputLike\` copies — kept in sync manually as before). \`runAgent\` gets a 13th positional param.
- \`claude-runtime\` + \`ollama-runtime\` set \`NANOCLAW_PORTAL_THREAD_ID\` env var in the MCP server env so child processes inherit it.
- \`send_message\` MCP tool reads the env var and includes \`threadId\` in the IPC payload. Empty = main-feed message (unchanged for non-portal runs).
- \`IpcDeps.sendMessage\` signature: gains optional \`threadId\`. Forwards \`data.threadId\` from the message file.
- Implementer in \`src/index.ts\` \`startIpcWatcher\` passes \`threadId\` to \`channel.sendMessage\` so portal routing kicks in on the web channel.
- Delegation handler's \`onOutput\` now also marks \`deliveredToUser\` when \`result\` is null but \`textsAlreadyStreamed > 0\`.

## Test plan

- [x] \`npm run build\` clean
- [x] 505/505 tests pass
- [x] Container image rebuilt + warm pool flushed
- [x] Smoke: action triggers \`Researcher\` to fire \`send_message\` three times (\"alpha\", \"beta\", \"gamma\") plus a final summary. **All four messages stored in the portal thread\\\\. No leaks to the main feed.**
  ```
  portal-delegation-researcher-... | Researcher | alpha
  portal-delegation-researcher-... | Researcher | beta
  portal-delegation-researcher-... | Researcher | gamma
  portal-delegation-researcher-... | Researcher | Sent three messages: alpha, beta, gamma.
  ```

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)