### PR TITLE
Fix #84: delegation onText broadcasts progress instead of redelivering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3120,22 +3120,23 @@ async function main(): Promise<void> {
           },
           (event) => broadcastProgress(chatJid, event, portalThreadId),
           async (rawText) => {
+            // Match the normal-run onText pattern (#84): intermediate TEXT
+            // markers are progress signals, not chat messages. The final
+            // consolidated reply still arrives via onOutput. Previously this
+            // path called deliverAgentMessage per fragment, producing a
+            // stream of chattery sub-messages in the portal.
             const text = rawText
               .replace(/<internal>[\s\S]*?<\/internal>/g, '')
               .trim();
             if (!text) return;
             setActiveAgentName(chatJid, agent.displayName);
-            if (
-              await deliverAgentMessage(
-                channel,
-                chatJid,
-                text,
-                lease,
-                portalThreadId,
-              )
-            ) {
-              deliveredToUser = true;
-            }
+            const summary =
+              text.length > 120 ? text.slice(0, 117) + '...' : text;
+            broadcastProgress(
+              chatJid,
+              { tool: 'text', summary, timestamp: new Date().toISOString() },
+              portalThreadId,
+            );
           },
           agent,
           true,


### PR DESCRIPTION
## Summary

The delegation handler's \`onText\` callback was calling \`deliverAgentMessage\` for every intermediate TEXT marker, producing a stream of chattery sub-messages in the portal/chat. The normal (non-delegation) run path already treats intermediate TEXT as progress signals — the final consolidated reply arrives through \`onOutput\`.

This aligns the delegation path with the normal one:

- Trim + skip empty text (unchanged)
- Compute a 120-char summary
- Emit a \`broadcastProgress\` event with \`tool: 'text'\` (and \`portalThreadId\` so the portal-scoped progress shard receives it)
- **Don't** call \`deliverAgentMessage\` — \`onOutput\` is responsible for the final reply

## Diff at the call site

\`\`\`diff
   (event) => broadcastProgress(chatJid, event, portalThreadId),
   async (rawText) => {
     const text = rawText.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
     if (!text) return;
     setActiveAgentName(chatJid, agent.displayName);
-    if (await deliverAgentMessage(channel, chatJid, text, lease, portalThreadId)) {
-      deliveredToUser = true;
-    }
+    const summary = text.length > 120 ? text.slice(0, 117) + '...' : text;
+    broadcastProgress(
+      chatJid,
+      { tool: 'text', summary, timestamp: new Date().toISOString() },
+      portalThreadId,
+    );
   },
\`\`\`

## Test plan

- [x] \`npm run build\` clean
- [x] 505/505 tests pass

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)