### PR TITLE
Fix #99: sound blocks no longer replay on re-render

### DIFF
--- a/web/js/components/AgentPanel.js
+++ b/web/js/components/AgentPanel.js
@@ -100,7 +100,7 @@ function LiveMessage({ msg }) {
         ${msg.senderName || (isUser ? 'user' : 'assistant')} · ${formatTime(msg.timestamp)}
       </div>
       <div class="text-xs leading-relaxed">
-        <${MessageBody} content=${msg.content} />
+        <${MessageBody} content=${msg.content} messageId=${msg.id} messageTimestamp=${msg.timestamp} />
       </div>
     </div>
   `;

--- a/web/js/components/Message.js
+++ b/web/js/components/Message.js
@@ -99,7 +99,7 @@ function UsageFooter({ usage, toolHistory, expanded, onToggle, runId, groupFolde
   `;
 }
 
-export function Message({ role, content, timestamp, senderName, isError, compact, usage, toolHistory, runId }) {
+export function Message({ id, role, content, timestamp, senderName, isError, compact, usage, toolHistory, runId }) {
   const isAssistant = role === 'assistant';
   const time = timestamp
     ? new Date(timestamp).toLocaleTimeString()
@@ -125,7 +125,7 @@ export function Message({ role, content, timestamp, senderName, isError, compact
       ${showAgentBadge && html`
         <div class="text-[11px] font-semibold mb-1" style="color: ${nameColor}">${senderName}</div>
       `}
-      <${MessageBody} content=${content} />
+      <${MessageBody} content=${content} messageId=${id} messageTimestamp=${timestamp} />
       <div class="text-[11px] text-txt-muted mt-1.5">
         ${senderName && !showAgentBadge ? `${senderName} \u00B7 ${time}` : time}
       </div>

--- a/web/js/components/MessageBody.js
+++ b/web/js/components/MessageBody.js
@@ -20,14 +20,24 @@ function handleMentionClick(e) {
  * Prefers structured block rendering when the content parses as blocks,
  * falls back to markdown for plain text. Keep this the single path for
  * message content so new surfaces get the same behavior for free.
+ *
+ * messageId and messageTimestamp flow down so blocks like SoundBlock
+ * can gate side-effects (playback) on per-instance identity instead of
+ * firing every time the surface re-renders (#99).
  */
-export function MessageBody({ content }) {
+export function MessageBody({ content, messageId, messageTimestamp }) {
   if (!content) return null;
   const blocks = parseBlocks(content);
   if (blocks) {
     return html`
       <div class="block-container" onClick=${handleMentionClick}>
-        ${blocks.map((block, i) => html`<${BlockRenderer} key=${i} block=${block} />`)}
+        ${blocks.map((block, i) => html`<${BlockRenderer}
+          key=${i}
+          block=${block}
+          messageId=${messageId}
+          messageTimestamp=${messageTimestamp}
+          blockIndex=${i}
+        />`)}
       </div>
     `;
   }

--- a/web/js/components/MessageList.js
+++ b/web/js/components/MessageList.js
@@ -126,6 +126,7 @@ export function MessageList() {
                 class=${flashing ? 'notif-flash' : ''}
               >
                 <${Message}
+                  id=${m.id}
                   role=${m.role}
                   content=${m.content}
                   timestamp=${m.timestamp}

--- a/web/js/components/blocks/BlockRenderer.js
+++ b/web/js/components/blocks/BlockRenderer.js
@@ -28,7 +28,15 @@ const RENDERERS = {
   image: ImageBlock,
 };
 
-export function BlockRenderer({ block }) {
+export function BlockRenderer({ block, messageId, messageTimestamp, blockIndex }) {
   const Component = RENDERERS[block.type] || TextBlock;
-  return html`<${Component} ...${block} />`;
+  // SoundBlock uses messageId/messageTimestamp/blockIndex to skip
+  // playback on re-renders (group switch, refresh) — see #99. Other
+  // blocks ignore the extra props.
+  return html`<${Component}
+    ...${block}
+    messageId=${messageId}
+    messageTimestamp=${messageTimestamp}
+    blockIndex=${blockIndex}
+  />`;
 }

--- a/web/js/components/blocks/SoundBlock.js
+++ b/web/js/components/blocks/SoundBlock.js
@@ -1,6 +1,14 @@
 import { html } from 'htm/preact';
-import { useEffect, useRef } from 'preact/hooks';
+import { useEffect } from 'preact/hooks';
 import { TONES, isMuted } from '../../sounds.js';
+
+// Tracks which sound blocks have already been played in this browser
+// session so re-renders (group switch, drawer toggles, scrolling) don't
+// replay them. Cleared naturally on full page reload — combined with
+// the sessionStart gate below, that means historical sounds don't replay
+// after a refresh either. (#99)
+const playedKeys = new Set();
+const sessionStartMs = Date.now();
 
 // Play a custom tone definition
 function playCustom(notes) {
@@ -34,19 +42,40 @@ function playCustom(notes) {
   }
 }
 
-export function SoundBlock({ tone, custom, label }) {
-  const played = useRef(false);
+export function SoundBlock({
+  tone,
+  custom,
+  label,
+  messageId,
+  messageTimestamp,
+  blockIndex,
+}) {
+  // Stable per-instance key. Prefer messageId+index when available
+  // (carries through across remounts), fall back to JSON content (will
+  // collapse two identical sounds in the same message — acceptable).
+  const key =
+    messageId != null
+      ? `${messageId}::${blockIndex ?? 0}`
+      : JSON.stringify({ tone, custom: custom || null, label: label || null });
 
   useEffect(() => {
-    if (played.current) return;
-    played.current = true;
+    if (playedKeys.has(key)) return;
+    playedKeys.add(key);
+
+    // Don't play sounds that arrived before this browser session started
+    // — they're historical content, not new events. Avoids the "every
+    // sound in chat history blares on page load" problem.
+    if (messageTimestamp) {
+      const ts = new Date(messageTimestamp).getTime();
+      if (Number.isFinite(ts) && ts < sessionStartMs) return;
+    }
 
     if (custom) {
       playCustom(custom);
     } else if (tone && TONES[tone]) {
       if (!isMuted()) TONES[tone].play();
     }
-  }, []);
+  }, [key]);
 
   // Visual indicator
   const displayName = tone


### PR DESCRIPTION
## Summary

Sound blocks were replaying on every group switch. The previous \`SoundBlock\` used a per-instance \`useRef\` to gate playback — which is reset every time the component remounts. Switching groups unmounted/remounted the message list, so every sound block in history fired again on return.

## Two-layer fix

1. **Module-level \`playedKeys\` Set.** Survives remounts within the same browser session. Key is \`messageId+blockIndex\` when available, falls back to JSON-content hash. Group switches no longer replay.

2. **Session-start timestamp gate.** \`sessionStartMs\` is captured on module import. Sounds in messages whose timestamp predates the page load skip playback entirely. Full reloads no longer blare every historical sound.

## Threading

\`MessageBody\` now accepts \`messageId + messageTimestamp\` and forwards them through \`BlockRenderer\`. Other block types ignore the extra props. \`Message\` and \`AgentPanel\`'s \`LiveMessage\` updated to pass \`m.id\` and \`m.timestamp\`.

## Test plan

- [x] \`npm run build\` clean
- [x] 505/505 tests pass
- [ ] Manual: emit a sound, switch groups and back — no replay
- [ ] Manual: reload page — historical sounds don't blare

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)