### PR TITLE
Fix scheduled tasks missing delegation tools in multi-agent groups

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ export const TRIGGER_IDLE_TIMEOUT = parseInt(
 ); // 1min default — shorter timeout for triggered agents
 export const MAX_CONCURRENT_CONTAINERS = Math.max(
   1,
-  parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
+  parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '7', 10) || 7,
 );
 export const WARM_POOL_ENABLED =
   (process.env.WARM_POOL_ENABLED || envConfig.WARM_POOL_ENABLED) === 'true';

--- a/src/model-capabilities.test.ts
+++ b/src/model-capabilities.test.ts
@@ -30,13 +30,13 @@ describe('getCapabilityProfile', () => {
     const p = getCapabilityProfile(undefined);
     expect(p.receivesMcpTools).toBe(true);
     expect(p.streaming).toBe('chunked');
-    expect(p.delegationTimeoutMs).toBe(120_000);
+    expect(p.delegationTimeoutMs).toBe(180_000);
   });
 
   it('returns the anthropic profile for explicit anthropic', () => {
     const p = getCapabilityProfile({ provider: 'anthropic' });
     expect(p.receivesMcpTools).toBe(true);
-    expect(p.delegationTimeoutMs).toBe(120_000);
+    expect(p.delegationTimeoutMs).toBe(180_000);
   });
 
   it('reports small ollama models as tool-less (not on the allowlist)', () => {

--- a/src/model-capabilities.ts
+++ b/src/model-capabilities.ts
@@ -54,7 +54,7 @@ export interface CapabilityProfile {
 const ANTHROPIC_PROFILE: CapabilityProfile = {
   receivesMcpTools: true,
   streaming: 'chunked',
-  delegationTimeoutMs: 120_000, // 2 min — fast cloud API, fail fast on hangs
+  delegationTimeoutMs: 180_000, // 3 min — allows headroom for large prompts
 };
 
 // Ollama streaming is always per-token on the wire (the host buffers in

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -3,6 +3,7 @@ import { CronExpressionParser } from 'cron-parser';
 import fs from 'fs';
 
 import { getAchievementsForContainer } from './achievements.js';
+import { buildMultiAgentContext, discoverAgents } from './agent-discovery.js';
 import { ASSISTANT_NAME, SCHEDULER_POLL_INTERVAL, TIMEZONE } from './config.js';
 import {
   ContainerOutput,
@@ -22,6 +23,10 @@ import { evaluateAutomationRules } from './automation-rules.js';
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
 import { logger } from './logger.js';
+import {
+  resolveEffectiveRuntime,
+  resolveTurnConstraints,
+} from './runtime-resolution.js';
 import { RegisteredGroup, ScheduledTask } from './types.js';
 
 /**
@@ -137,6 +142,15 @@ async function runTask(
     return;
   }
 
+  // Resolve agents so scheduled tasks get the same agent-aware container
+  // input as interactive runs (canDelegate, systemContext, runtime, etc.).
+  const agents = discoverAgents(group);
+  const coordinator = agents.find((a) => !a.trigger) || agents[0];
+  const isMultiAgent = agents.length > 1;
+  const multiAgentCtx = isMultiAgent
+    ? buildMultiAgentContext(coordinator, agents)
+    : undefined;
+
   // Update tasks snapshot for container to read (filtered by group)
   const isMain = group.isMain === true;
   const tasks = getAllTasks();
@@ -189,7 +203,13 @@ async function runTask(
         chatJid: task.chat_jid,
         isMain,
         isScheduledTask: true,
-        assistantName: ASSISTANT_NAME,
+        assistantName: coordinator.displayName || ASSISTANT_NAME,
+        agentId: coordinator.id,
+        agentName: coordinator.name,
+        runtime: resolveEffectiveRuntime(coordinator, task.group_folder),
+        constraints: resolveTurnConstraints(coordinator, group),
+        canDelegate: !coordinator.trigger,
+        systemContext: multiAgentCtx,
         mainChatJid: isMain ? undefined : deps.getMainChatJid?.(),
         script: task.script || undefined,
         achievements: getAchievementsForContainer(),


### PR DESCRIPTION
## Summary

- Scheduled tasks called `runContainerAgent` without `canDelegate`, `agentName`, `agentId`, `runtime`, `constraints`, or `systemContext` — the coordinator container never got `NANOCLAW_CAN_DELEGATE=1`, so the `delegate_to_agent` MCP tool was never registered
- Now discovers agents in the task scheduler, resolves the coordinator, and passes the same agent-aware container input that the interactive message path uses
- Also bumps Anthropic delegation timeout from 120s to 180s (observed 128s runs timing out) and max concurrent containers from 5 to 7 (coordinator + 5 specialists no longer queues)

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — all 514 tests pass (including task-scheduler and model-capabilities tests)
- [ ] Manual: restart service, trigger a scheduled task run in a multi-agent group, verify coordinator can delegate by checking logs for `delegate_to_agent` IPC calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)