### PR TITLE
End Ollama tool loop after user-visible tool calls (#75)

### DIFF
--- a/container/agent-runner/src/ollama-runtime.test.ts
+++ b/container/agent-runner/src/ollama-runtime.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  USER_VISIBLE_TOOL_NAMES,
+  isUserVisibleTool,
+} from './ollama-runtime.js';
+
+describe('isUserVisibleTool', () => {
+  it('returns true for tools whose execution produces a user-facing message', () => {
+    expect(isUserVisibleTool('mcp__nanoclaw__send_message')).toBe(true);
+    expect(isUserVisibleTool('mcp__nanoclaw__publish_media')).toBe(true);
+    expect(isUserVisibleTool('mcp__nanoclaw__publish_browser_snapshot')).toBe(
+      true,
+    );
+    expect(isUserVisibleTool('mcp__nanoclaw__escalate')).toBe(true);
+  });
+
+  it('returns false for side-effect tools that should not terminate the loop', () => {
+    expect(isUserVisibleTool('mcp__nanoclaw__set_agent_status')).toBe(false);
+    expect(isUserVisibleTool('mcp__nanoclaw__unlock_achievement')).toBe(false);
+    expect(isUserVisibleTool('mcp__nanoclaw__play_sound')).toBe(false);
+    expect(isUserVisibleTool('mcp__nanoclaw__set_subtitle')).toBe(false);
+  });
+
+  it('returns false for unknown / hallucinated tool names', () => {
+    expect(isUserVisibleTool('mcp__nanoclaw__fictional_tool')).toBe(false);
+    expect(isUserVisibleTool('')).toBe(false);
+    expect(isUserVisibleTool('send_message')).toBe(false);
+  });
+
+  it('exports a frozen-feeling set so callers cannot mutate the contract', () => {
+    expect(USER_VISIBLE_TOOL_NAMES.has('mcp__nanoclaw__send_message')).toBe(
+      true,
+    );
+    expect(USER_VISIBLE_TOOL_NAMES.size).toBe(4);
+  });
+});

--- a/container/agent-runner/src/ollama-runtime.ts
+++ b/container/agent-runner/src/ollama-runtime.ts
@@ -66,6 +66,29 @@ export async function ollamaModelSupportsTools(model: string): Promise<boolean> 
 
 const MAX_TOOL_TURNS = 10;
 
+/**
+ * Tools whose execution itself produces a user-visible message in the chat.
+ * After the model invokes one, we exit the tool loop without giving it
+ * another turn — Ollama models trained on tool-use are prone to emit a
+ * conversational summary after a tool ("Hello!" after a `send_message`
+ * that already greeted the user), which lands as a duplicate bubble.
+ *
+ * See #75 for the full analysis. Side-effect tools (set_agent_status,
+ * unlock_achievement, play_sound, etc.) are intentionally absent — they
+ * don't produce visible content, so the model should still get a turn
+ * to author the actual reply afterwards.
+ */
+export const USER_VISIBLE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'mcp__nanoclaw__send_message',
+  'mcp__nanoclaw__publish_media',
+  'mcp__nanoclaw__publish_browser_snapshot',
+  'mcp__nanoclaw__escalate',
+]);
+
+export function isUserVisibleTool(qualifiedName: string): boolean {
+  return USER_VISIBLE_TOOL_NAMES.has(qualifiedName);
+}
+
 interface ContainerInputLike {
   chatJid: string;
   groupFolder: string;
@@ -376,6 +399,7 @@ export class OllamaRuntime {
             content: response.message.content ?? '',
             tool_calls: toolCalls,
           });
+          let userVisibleDelivered = false;
           for (const call of toolCalls) {
             const name = call.function.name;
             const args = call.function.arguments ?? {};
@@ -386,7 +410,18 @@ export class OllamaRuntime {
               content: result.content,
               tool_name: name,
             });
-            if (!result.isError) deliveredViaTools = true;
+            if (!result.isError) {
+              deliveredViaTools = true;
+              if (isUserVisibleTool(name)) userVisibleDelivered = true;
+            }
+          }
+          // If any successful tool call already delivered user-visible
+          // content, end the turn — see USER_VISIBLE_TOOL_NAMES (#75).
+          if (userVisibleDelivered) {
+            log(
+              `Ollama: ${model} delivered user-visible content via tool; ending turn`,
+            );
+            break;
           }
           continue;
         }


### PR DESCRIPTION
## Summary

- Tag `send_message`, `publish_media`, `publish_browser_snapshot`, and `escalate` as tools that themselves deliver user-facing chat content.
- When the model successfully invokes one, exit the tool loop immediately — no extra turn, no redundant follow-up bubble.
- Side-effect tools (`set_agent_status`, `unlock_achievement`, `play_sound`, …) are intentionally outside the set, so the model still gets a turn to author the real reply after them.

Fixes #75.

## Why this shape

Two earlier tradeoffs from the issue, kept:

- **Don't suppress final text unconditionally** when `deliveredViaTools` is true — that risks dropping novel content the model legitimately produces after a side-effect tool. Termination is gated on the *kind* of tool, not on the fact that any tool ran.
- **Hardcoded set, not MCP metadata** — the user-visible-tool list is small (4 entries), the property is a runtime-loop concern not a tool-author concern, and it generalises cleanly to a future OpenAI / openrouter adapter that runs its own loop. Single source of truth in one file.

## Test plan

- [x] `npm test` in `container/agent-runner` (12 passed, 4 new for `isUserVisibleTool`)
- [x] `npm run build` clean on host and container
- [x] Live ship-gate against `qwen2.5-coder:7b` (CPU Ollama in WSL):
  - Sent `@analyst what do you think about TypeScript versus Python?`
  - Received exactly one `Analyst` bubble (521 chars of analysis), no redundant follow-up
  - Host log shows the post-fix signature `WARN: Agent returned null result after retry — silent completion` — confirms `result: null` + `textsAlreadyStreamed: 1` (loop terminated, no second-turn text emitted)

## Side issues surfaced during validation (not in this PR)

These bit me during the ship-gate; both deserve their own tickets:

1. **`AUTOMATION_TIMEOUT = 120_000`** at `src/index.ts:784` is hardcoded and ignores the per-model `delegationTimeoutMs` from the capability profile. CPU Ollama with a tool-capable 7B can't finish a tool turn in 2 minutes; killed the first attempt.
2. **Capability cache cold-start race** at `src/runtime-resolution.ts:182` — when `getOllamaCapabilities(model)` misses, `getCapabilityProfile` returns `OLLAMA_TEXT_ONLY_PROFILE` (`receivesMcpTools: false`) and only schedules an async refresh. The first delegation after a cold start runs without role narrowing (17 tools instead of 2). Either warm the cache synchronously at agent-discovery time, or pessimistically narrow on cache miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)