### PR TITLE
Clear chat removes delegation indicators (#116)

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6,6 +6,7 @@ import {
   loadPortalStateFor,
   addLiveThreadForJid,
   setDrawerStateFor,
+  savePortalStateFor,
 } from './portal-persistence.js';
 import { playNotification, TONES, isMuted } from './sounds.js';
 import { App } from './components/App.js';
@@ -547,11 +548,35 @@ api.onSSE('achievement', (data) => {
 });
 
 api.onSSE('messages_cleared', (data) => {
+  // The server has already deleted threads for this jid (clearMessages drops
+  // both trigger and portal rows). Mirror that on the client so portal pills,
+  // tool-activity feeds, and persisted drawer state all disappear without
+  // requiring a page refresh — see #116.
+  const droppedThreadIds = new Set();
+  const remainingPortals = {};
+  for (const [tid, portal] of Object.entries(portalThreads.value)) {
+    if (portal.jid === data.jid) {
+      droppedThreadIds.add(tid);
+    } else {
+      remainingPortals[tid] = portal;
+    }
+  }
+  if (droppedThreadIds.size > 0) {
+    portalThreads.value = remainingPortals;
+    const remainingProgress = {};
+    for (const [tid, prog] of Object.entries(portalProgress.value)) {
+      if (!droppedThreadIds.has(tid)) remainingProgress[tid] = prog;
+    }
+    portalProgress.value = remainingProgress;
+  }
+  savePortalStateFor(data.jid, { liveThreadIds: [], drawer: null });
+
   if (data.jid === selectedJid.value) {
     messages.value = [];
     threadMeta.value = {};
     openThreads.value = {};
     threadTyping.value = {};
+    if (agentPanel.value) agentPanel.value = null;
   }
 });
 


### PR DESCRIPTION
## Summary

- The `messages_cleared` SSE handler now mirrors the server-side delete that already happens in `clearMessages`. After a clear, `portalThreads`, `portalProgress`, and the persisted `liveThreadIds` + drawer for the affected jid are all dropped.
- If the cleared chat is currently selected, also close the side drawer (`agentPanel = null`) — its content references threads that no longer exist.

Fixes #116.

## Why this shape

Server-side `clearMessages` already deletes both `kind='trigger'` and `kind='portal'` threads for the chat, but the SSE handler only cleared the inline thread state — it left portal pills, their tool-activity feed, and the per-jid `clawdad-portal-panel-state` localStorage entry intact. A page refresh would silently drop them on the next chat load (server returns no portals → client renders none). Without a refresh, they appeared to "stick."

The fix runs the portal-state cleanup unconditionally for the cleared jid (not gated on `selectedJid`) so a clear in another tab also reaches a consistent state on the next focus, and the persisted state never points at deleted threads.

## Verification

- [x] Server contract verified end-to-end via `POST /api/action` → `GET /api/portal-threads/:jid` (portal listed) → `DELETE /api/messages/:jid` → `GET /api/portal-threads/:jid` (empty)
- [x] SSE event shapes confirmed against a live `/api/events` stream — `thread_opened` carries `{ jid, thread_id, agent_name, kind: 'portal', source_agent, title }`, `messages_cleared` carries `{ jid }`
- [x] Visual: portal pills disappear immediately on Clear Chat without a page refresh
- [x] `npm run build` clean on host; `node --check` clean on `web/js/app.js`

## Side issue surfaced during validation (not in this PR)

While testing, the test-team coordinator container started crashlooping with `TS2305: Module '"./ollama-runtime.js"' has no exported member 'USER_VISIBLE_TOOL_NAMES'`. Root cause: `container-runner.ts` uses `fs.cpSync` to refresh `data/sessions/<group>/<agent>/agent-runner-src/` from `container/agent-runner/src/` on mtime change, but `cpSync` is additive — files removed from the source dir (e.g. by switching git branches) stay in the cache and break the in-container `tsc` step. Filed as #120 with a small proposed fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)