### PR TITLE
Add manual task triggering and failure visibility

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -92,6 +92,8 @@ export interface ChannelOpts {
   onResetSession?: (groupFolder: string) => Promise<void>;
   /** Get fully discovered agents for a group with runtime metadata */
   getDiscoveredAgents?: (jid: string) => Agent[];
+  /** Manually trigger a scheduled task to run (web UI "run now" button) */
+  onRunTaskNow?: (taskId: string) => void;
 }
 
 export type ChannelFactory = (opts: ChannelOpts) => Channel | null;

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -350,6 +350,27 @@ export class WebChannel implements Channel {
     this.broadcast('groups_changed', {});
   }
 
+  /** Surface a scheduled-task failure to the notification bell + sidebar. */
+  broadcastTaskFailed(event: {
+    taskId: string;
+    taskTitle: string;
+    groupFolder: string;
+    groupName: string;
+    chatJid: string;
+    error: string;
+    runAt: string;
+  }): void {
+    this.broadcast('task_failed', {
+      task_id: event.taskId,
+      task_title: event.taskTitle,
+      group_folder: event.groupFolder,
+      group_name: event.groupName,
+      jid: event.chatJid,
+      error: event.error,
+      run_at: event.runAt,
+    });
+  }
+
   private sanitizeAgentName(name: string): string {
     return name.toLowerCase().replace(/[^a-z0-9_-]/g, '-');
   }
@@ -1805,6 +1826,27 @@ You do not delegate. If something falls outside your role, say so plainly in you
       updateTask(taskId, { status: 'paused' });
       this.broadcastGroupsChanged();
       return this.json(res, 200, { ok: true });
+    }
+
+    // POST /api/tasks/:id/run — manually trigger a task immediately
+    const taskRunMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)\/run$/);
+    if (method === 'POST' && taskRunMatch) {
+      const taskId = decodeURIComponent(taskRunMatch[1]);
+      const task = getTaskById(taskId);
+      if (!task) return this.json(res, 404, { error: 'Task not found' });
+      if (!this.opts.onRunTaskNow) {
+        return this.json(res, 503, {
+          error: 'Manual task trigger not wired on this channel',
+        });
+      }
+      try {
+        this.opts.onRunTaskNow(taskId);
+      } catch (err) {
+        return this.json(res, 500, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return this.json(res, 202, { ok: true });
     }
 
     // POST /api/tasks/:id/resume — resume a task

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,11 @@ import {
   evaluateAutomationRules,
   AutomationTraceEntry,
 } from './automation-rules.js';
-import { startSchedulerLoop } from './task-scheduler.js';
+import {
+  runTaskNow,
+  startSchedulerLoop,
+  type SchedulerDependencies,
+} from './task-scheduler.js';
 import { Agent, Channel, NewMessage, RegisteredGroup } from './types.js';
 import type { MediaArtifact } from './types.js';
 import { logger } from './logger.js';
@@ -2991,8 +2995,7 @@ async function main(): Promise<void> {
     }
   };
 
-  // Start subsystems (independently of connection handler)
-  startSchedulerLoop({
+  const schedulerDeps: SchedulerDependencies = {
     registeredGroups: () => registeredGroups,
     getSessions: () => sessions,
     queue,
@@ -3030,7 +3033,26 @@ async function main(): Promise<void> {
     onProgress: (jid, event) => broadcastProgress(jid, event),
     getMainChatJid,
     onTasksChanged,
-  });
+    onTaskFailed: (event) => {
+      for (const ch of channels) {
+        if (ch.name === 'web' && 'broadcastTaskFailed' in ch) {
+          (
+            ch as { broadcastTaskFailed: (e: typeof event) => void }
+          ).broadcastTaskFailed(event);
+          break;
+        }
+      }
+    },
+  };
+
+  // Wire manual task triggering on the same deps as the scheduler loop —
+  // mirrors the `onUserDelegation` pattern: opts are post-attached because
+  // schedulerDeps depends on `channels`, which is populated above.
+  channelOpts.onRunTaskNow = (taskId: string) =>
+    runTaskNow(taskId, schedulerDeps);
+
+  // Start subsystems (independently of connection handler)
+  startSchedulerLoop(schedulerDeps);
 
   // Delegation handler — invokable from both the IPC MCP tool (coordinator
   // calls delegate_to_agent) and the web channel (action-button click with

--- a/src/task-scheduler.ts
+++ b/src/task-scheduler.ts
@@ -65,6 +65,16 @@ export function computeNextRun(task: ScheduledTask): string | null {
   return null;
 }
 
+export interface TaskFailureEvent {
+  taskId: string;
+  taskTitle: string;
+  groupFolder: string;
+  groupName: string;
+  chatJid: string;
+  error: string;
+  runAt: string;
+}
+
 export interface SchedulerDependencies {
   registeredGroups: () => Record<string, RegisteredGroup>;
   getSessions: () => Record<string, string>;
@@ -80,9 +90,10 @@ export interface SchedulerDependencies {
   onProgress?: (jid: string, event: ProgressEvent) => void;
   getMainChatJid?: () => string | undefined;
   onTasksChanged?: () => void;
+  onTaskFailed?: (event: TaskFailureEvent) => void;
 }
 
-async function runTask(
+export async function runTask(
   task: ScheduledTask,
   deps: SchedulerDependencies,
   queueJid: string,
@@ -252,10 +263,11 @@ async function runTask(
   }
 
   const durationMs = Date.now() - startTime;
+  const runAt = new Date().toISOString();
 
   logTaskRun({
     task_id: task.id,
-    run_at: new Date().toISOString(),
+    run_at: runAt,
     duration_ms: durationMs,
     status: error ? 'error' : 'success',
     result,
@@ -269,9 +281,41 @@ async function runTask(
       ? result.slice(0, 200)
       : 'Completed';
   updateTaskAfterRun(task.id, nextRun, resultSummary);
+
+  if (error) {
+    deps.onTaskFailed?.({
+      taskId: task.id,
+      taskTitle: task.title || task.prompt.split('\n')[0].slice(0, 80),
+      groupFolder: task.group_folder,
+      groupName: group?.name || task.group_folder,
+      chatJid: task.chat_jid,
+      error,
+      runAt,
+    });
+  }
+
   // next_run has advanced — refresh snapshots + broadcast so the web UI
   // re-sorts the sidebar when sorted by upcoming schedule.
   deps.onTasksChanged?.();
+}
+
+/**
+ * Manually trigger a task to run as soon as the group queue is free.
+ * Mirrors the scheduler-loop dispatch logic so the same code path executes.
+ */
+export function runTaskNow(taskId: string, deps: SchedulerDependencies): void {
+  const task = getTaskById(taskId);
+  if (!task) {
+    throw new Error(`Task not found: ${taskId}`);
+  }
+  const groups = deps.registeredGroups();
+  const queueJid =
+    Object.keys(groups).find(
+      (jid) => groups[jid].folder === task.group_folder,
+    ) ?? task.chat_jid;
+  deps.queue.enqueueTask(queueJid, task.id, () =>
+    runTask(task, deps, queueJid),
+  );
 }
 
 let schedulerRunning = false;

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -122,6 +122,8 @@ export const resumeTask = (taskId) =>
   fetchJson(`/api/tasks/${encodeURIComponent(taskId)}/resume`, { method: 'POST' });
 export const cancelTask = (taskId) =>
   fetchJson(`/api/tasks/${encodeURIComponent(taskId)}`, { method: 'DELETE' });
+export const runTaskNow = (taskId) =>
+  fetchJson(`/api/tasks/${encodeURIComponent(taskId)}/run`, { method: 'POST' });
 export const getTelemetry = () => fetchJson('/api/telemetry');
 export const getUsage = (hours = 24) => fetchJson(`/api/usage?hours=${hours}`);
 export const updateGroup = (folder, data) =>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -6,6 +6,7 @@ import {
   loadPortalStateFor,
   addLiveThreadForJid,
   setDrawerStateFor,
+  savePortalStateFor,
 } from './portal-persistence.js';
 import { playNotification, TONES, isMuted } from './sounds.js';
 import { App } from './components/App.js';
@@ -547,11 +548,35 @@ api.onSSE('achievement', (data) => {
 });
 
 api.onSSE('messages_cleared', (data) => {
+  // The server has already deleted threads for this jid (clearMessages drops
+  // both trigger and portal rows). Mirror that on the client so portal pills,
+  // tool-activity feeds, and persisted drawer state all disappear without
+  // requiring a page refresh — see #116.
+  const droppedThreadIds = new Set();
+  const remainingPortals = {};
+  for (const [tid, portal] of Object.entries(portalThreads.value)) {
+    if (portal.jid === data.jid) {
+      droppedThreadIds.add(tid);
+    } else {
+      remainingPortals[tid] = portal;
+    }
+  }
+  if (droppedThreadIds.size > 0) {
+    portalThreads.value = remainingPortals;
+    const remainingProgress = {};
+    for (const [tid, prog] of Object.entries(portalProgress.value)) {
+      if (!droppedThreadIds.has(tid)) remainingProgress[tid] = prog;
+    }
+    portalProgress.value = remainingProgress;
+  }
+  savePortalStateFor(data.jid, { liveThreadIds: [], drawer: null });
+
   if (data.jid === selectedJid.value) {
     messages.value = [];
     threadMeta.value = {};
     openThreads.value = {};
     threadTyping.value = {};
+    if (agentPanel.value) agentPanel.value = null;
   }
 });
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -584,6 +584,21 @@ api.onSSE('groups_changed', () => {
   loadGroups();
 });
 
+api.onSSE('task_failed', (data) => {
+  // Surface in the notification bell + refresh tasks so the group row
+  // picks up the red "!" badge derived from last_result.
+  pushNotification({
+    id: `task-failed:${data.task_id}:${data.run_at}`,
+    jid: data.jid,
+    kind: 'task_failed',
+    groupName: data.group_name || data.group_folder,
+    senderName: data.task_title || 'Scheduled task',
+    preview: data.error || 'Task failed',
+    timestamp: data.run_at || new Date().toISOString(),
+  });
+  pollTasks();
+});
+
 api.onSSE('credential_request', (data) => {
   // Deduplicate — ignore if we already have a request for this service active or queued
   if (credentialRequest.value?.service === data.service) return;
@@ -995,6 +1010,13 @@ export async function resumeTask(taskId) {
 
 export async function cancelTask(taskId) {
   await api.cancelTask(taskId);
+  await pollTasks();
+}
+
+export async function runTaskNow(taskId) {
+  await api.runTaskNow(taskId);
+  // The actual run is async — pollTasks here just refreshes status.
+  // The SSE-driven update + onTasksChanged broadcast handles the rest.
   await pollTasks();
 }
 

--- a/web/js/components/GroupItem.js
+++ b/web/js/components/GroupItem.js
@@ -74,6 +74,12 @@ export function GroupItem({ group, isActive, onSelect, onSettings }) {
   const pausedTaskCount = groupTasks.filter(t => t.status === 'paused').length;
   const completedTaskCount = groupTasks.filter(t => t.status === 'completed').length;
   const hasTasks = groupTasks.length > 0;
+  // Auto-clears when the next run overwrites last_result with a success summary.
+  const failedTasks = groupTasks.filter(t => typeof t.last_result === 'string' && t.last_result.startsWith('Error:'));
+  const failedTaskCount = failedTasks.length;
+  const failedTaskTooltip = failedTaskCount > 0
+    ? `${failedTaskCount} task${failedTaskCount === 1 ? '' : 's'} failed: ${failedTasks.map(t => (t.title || t.prompt.split('\n')[0]).slice(0, 40)).join(', ')}`
+    : '';
   // Label: lead with whatever's non-zero so paused-only and completed-only
   // groups still surface a badge the user can click.
   const taskBadgeLabel = activeTaskCount > 0
@@ -138,6 +144,20 @@ export function GroupItem({ group, isActive, onSelect, onSettings }) {
         `}
         ${group.isMain && !group.isSystem && html`
           <span class="text-[10px] px-1.5 py-0.5 rounded bg-accent-dim text-accent font-medium shrink-0">main</span>
+        `}
+        ${failedTaskCount > 0 && html`
+          <button
+            class="w-[18px] h-[18px] mt-0.5 flex items-center justify-center text-err shrink-0 hover:brightness-110"
+            title="${failedTaskTooltip} — click to ${tasksExpanded ? 'collapse' : 'expand'}"
+            onClick=${handleTasksExpand}
+            aria-label="Task failed"
+          >
+            <svg class="w-[18px] h-[18px] block" viewBox="0 0 20 20" aria-hidden="true">
+              <circle cx="10" cy="10" r="9" fill="currentColor" />
+              <rect x="9" y="4.5" width="2" height="7" rx="1" fill="var(--bg)" />
+              <circle cx="10" cy="14.5" r="1.1" fill="var(--bg)" />
+            </svg>
+          </button>
         `}
         ${hasTasks && !count && html`
           <button

--- a/web/js/components/NotificationBell.js
+++ b/web/js/components/NotificationBell.js
@@ -83,6 +83,7 @@ export function NotificationBell() {
               <div class="max-h-[min(70vh,28rem)] overflow-y-auto">
                 ${entries.map((n) => {
                   const isUnread = !lastRead[n.jid] || n.timestamp > lastRead[n.jid];
+                  const isFailure = n.kind === 'task_failed';
                   return html`
                     <button
                       key=${n.id}
@@ -90,12 +91,15 @@ export function NotificationBell() {
                       onClick=${() => handleEntryClick(n)}
                     >
                       <span
-                        class="w-1.5 h-1.5 rounded-full flex-shrink-0 mt-1.5 ${isUnread ? 'bg-accent' : 'bg-transparent'}"
+                        class="w-1.5 h-1.5 rounded-full flex-shrink-0 mt-1.5 ${isUnread ? (isFailure ? 'bg-err' : 'bg-accent') : 'bg-transparent'}"
                         aria-hidden="true"
                       />
                       <div class="min-w-0 flex-1">
                         <div class="flex items-center gap-2 text-xs">
-                          <span class="font-semibold text-txt truncate">${esc(n.senderName || 'Agent')}</span>
+                          ${isFailure && html`
+                            <span class="text-err font-bold shrink-0" title="Task failed" aria-hidden="true">!</span>
+                          `}
+                          <span class="font-semibold ${isFailure ? 'text-err' : 'text-txt'} truncate">${esc(n.senderName || 'Agent')}</span>
                           <span class="text-txt-muted truncate">${esc(n.groupName)}</span>
                           <span class="text-txt-muted ml-auto shrink-0">${formatRelative(n.timestamp)}</span>
                         </div>

--- a/web/js/components/TaskItem.js
+++ b/web/js/components/TaskItem.js
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact';
 import { useState } from 'preact/hooks';
-import { pauseTask, resumeTask, cancelTask, getTaskLogs } from '../app.js';
+import { pauseTask, resumeTask, cancelTask, getTaskLogs, runTaskNow } from '../app.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 
 function relativeTime(iso) {
@@ -37,6 +37,7 @@ function describeCron(expr) {
 // SVG icons as tiny components
 const PauseIcon = () => html`<svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>`;
 const PlayIcon = () => html`<svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/></svg>`;
+const BoltIcon = () => html`<svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/></svg>`;
 const TrashIcon = () => html`<svg class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>`;
 const ChevronIcon = ({ open }) => html`<svg class="w-3 h-3 transition-transform ${open ? 'rotate-90' : ''}" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/></svg>`;
 
@@ -84,6 +85,16 @@ export function TaskItem({ task, compact }) {
     }
   }
 
+  async function onRunNow(e) {
+    e.stopPropagation();
+    setActing(true);
+    try {
+      await runTaskNow(task.id);
+    } finally {
+      setActing(false);
+    }
+  }
+
   const dotColor = isPaused
     ? 'bg-yellow-400'
     : isCompleted
@@ -107,6 +118,14 @@ export function TaskItem({ task, compact }) {
         <span class="text-[11px] text-txt truncate flex-1 min-w-0">${title}</span>
         <span class="text-[10px] text-txt-muted font-mono shrink-0">${scheduleLabel}</span>
         <div class="flex items-center gap-0.5 shrink-0 opacity-0 group-hover/task:opacity-100 transition-opacity">
+          <button
+            class="p-0.5 rounded text-accent hover:bg-accent/10 transition-colors"
+            onClick=${onRunNow}
+            disabled=${acting}
+            title="Run now"
+          >
+            <${BoltIcon} />
+          </button>
           ${!isCompleted && html`
             <button
               class="p-0.5 rounded ${isPaused ? 'text-green-400 hover:bg-green-400/10' : 'text-yellow-400 hover:bg-yellow-400/10'} transition-colors"


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Two related additions to the scheduled-tasks UX:

**What**
- A "Run now" button on each task in the group's task list, so the user can trigger a scheduled task manually instead of waiting for its cron / interval.
- A red exclamation badge on the group row when any of its tasks last errored, plus a `task_failed` notification in the bell so failures don't silently disappear into the run-history accordion.

**Why**
Scheduled tasks were running silently — if one errored, the only way to find out was to expand the task drawer and read the last run log. There was also no way to dry-run a task you'd just edited without manually editing `next_run` or waiting for the next tick.

**How it works**
- `runTaskNow(taskId, deps)` is exported from `task-scheduler.ts` and reuses the same queueJid resolution + `GroupQueue.enqueueTask` path as the scheduler loop, so manual and scheduled runs go through identical code.
- `POST /api/tasks/:id/run` calls the new `onRunTaskNow` channel opt (wired post-channel-construction, mirroring `onUserDelegation`).
- The scheduler emits `onTaskFailed` after a failed run; the web channel broadcasts `task_failed` SSE which `app.js` turns into a `kind: 'task_failed'` notification entry. `NotificationBell` styles those entries with a red dot + red glyph.
- `GroupItem` derives the failure indicator from `tasks.value.filter(t => t.last_result?.startsWith('Error:'))`. Because `last_result` is overwritten on every run, the badge auto-clears on the next success — no extra dismissal state.

**How it was tested**
- `npm run build` clean.
- `task-scheduler.test.ts` 5/5 pass.
- Manually triggered a real task via `POST /api/tasks/:id/run` → 202, container spawned, ran end-to-end, result delivered (verified in `logs/nanoclaw.log`).
- 404 path verified for missing task IDs.