### PR TITLE
Remove logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 <p align="center">
-  <img src="assets/nanoclaw-logo.png" alt="ClawDad" width="400">
-</p>
-
-<p align="center">
   A container-native platform for building, running, and observing local AI agent teams.
 </p>
 


### PR DESCRIPTION
Removed logo image from README and retained description.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
